### PR TITLE
Announce RSS/Atom feed in <head>

### DIFF
--- a/src/layouts/home.njk
+++ b/src/layouts/home.njk
@@ -32,7 +32,8 @@
     <title>{{ title }}</title>
     <link rel="stylesheet" type="text/css" href="/assets/style.css">
     <link rel="icon" href="/assets/favicon.ico" />
-    <link rel="manifest" href="/manifest.json">    
+    <link rel="manifest" href="/manifest.json">
+    <link rel="alternate" type="application/atom+xml" href="https://devtoolstips.org/feed.xml" />
     <meta property="og:title" content="DevTools Tips">
     <meta property="og:url" content="https://devtoolstips.org{{ page.url }}">
     {% if page.url.includes('/tips/') %}


### PR DESCRIPTION
Heyooooo! Thanks for the great project.

I added `<link rel="alternate" type="application/atom+xml" href="https://devtoolstips.org/feed.xml" />` to the `<head>` so that RSS reader pick up the feed by just entering `https://devtoolstips.org`. 🙈