### PR TITLE
invert the filter colors in dark mode

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -258,6 +258,14 @@ header nav {
   width: 0;
   /* Make font in input the same as elsewhere, and prevent iOS from zooming on tap */
   font: inherit;
+  color: inherit;
+}
+
+@media (prefers-color-scheme: dark) {
+  .search input {
+    border: 2px solid var(--accent-color-lighter);
+    background: var(--accent-color-darker);
+  }
 }
 
 /* Content area */


### PR DESCRIPTION
The filter in dark mode was still dark text on light background, because in both dark and light mode the "accent-color-lighter" is lighter. a more robust change would be to switch to accent-color-more and accent-color-less to indicate more or less contrast with the background, but for now I just flip the colors in dark mode. 

Old filter:
![old filter](https://user-images.githubusercontent.com/41970/210972097-54e68b6f-785b-499d-a5be-385725071129.png)

New filter:
![new filter](https://user-images.githubusercontent.com/41970/210972136-9b94213d-fe5b-48ab-9936-8b639905131e.png)
