### PR TITLE
Highlight browser name in title, reword filter

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -550,6 +550,15 @@ footer a {
   left: -9999px;
 }
 
+.browser-name {
+  color: var(--accent-color-darker);
+}
+@media (prefers-color-scheme: dark) {
+  .browser-name {
+    color: var(--accent-color-lighter);
+  }
+}
+
 /* Lightbox */
 
 .lightbox-button {

--- a/src/browser.njk
+++ b/src/browser.njk
@@ -19,7 +19,7 @@
 }
 ---
 <div class="page-toolbar">
-  <h2>{{ collections[browser].length  }} {{ browser | processBrowserTagName | capitalize }} DevTools Tips</h2>
+  <h2>{{ collections[browser].length  }} <span class="browser-name">{{ browser | processBrowserTagName | capitalize }}</span> DevTools Tips </h2>
   {% include 'filter-tip-list.njk' %}
 </div>
 {% include 'unique-browser-features.njk' %}

--- a/src/includes/unique-browser-features.njk
+++ b/src/includes/unique-browser-features.njk
@@ -1,5 +1,5 @@
 <label class="unique-browser">
-    <span>Only show tips unique to this browser</span>
+    <span>Show tips that only work in {{ browser | processBrowserTagName | capitalize }}</span>
     <input type="checkbox">
 </label>
 <script async src="/assets/unique-browser-features.js"></script>


### PR DESCRIPTION
This highlights the browser name in the title at the top of a filtered page, and rewords "Only show tips unique to this browser" to "Show tips that only work in ${browser}"

![new header](https://user-images.githubusercontent.com/41970/210972771-1da104fb-5a2a-4d52-9643-620eb9fb617b.png)
