### PR TITLE
clean up the alt descriptions of all images

### DIFF
--- a/src/tips/en/add-new-devices.md
+++ b/src/tips/en/add-new-devices.md
@@ -14,6 +14,6 @@ But what's even better, is that you can create your own simulated devices. This 
 * From this screen, you can check or uncheck devices to customize the device drop-down, and you can click **Add Custom Device...** to add your own devices.
 * Choose a device name, dimensions, dpr, and user agent string, and submit. Your new device should now be available in the device drop-down!
 
-![GIF animation of the device mode in Firefox, showing how to customize the list of devices, including adding custom devices](/assets/img/add-new-devices.gif)
+![Animation of the device mode in Firefox, showing how to customize the list of devices, including adding custom devices.](/assets/img/add-new-devices.gif)
 
 In Polypane these steps are not needed. Double-click anywhere to add a new device and configure its settings from the **Emulation options**.

--- a/src/tips/en/automatically-log-name-and-value.md
+++ b/src/tips/en/automatically-log-name-and-value.md
@@ -32,6 +32,6 @@ document.body.addEventListener('click', e => {
 })
 ```
 
-![Screencast showing the different ways the variables are logged with and without curly braces](/assets/img/automatically-log-name-and-value.gif)
+![Animation showing the different ways the variables are logged with and without curly braces.](/assets/img/automatically-log-name-and-value.gif)
 
 https://www.youtube.com/watch?v=xTnqsA5vZX4

--- a/src/tips/en/block-resources.md
+++ b/src/tips/en/block-resources.md
@@ -16,7 +16,7 @@ With DevTools you can block individual URLs or more global patterns.
   * Reload the page
   * You can also use the **Network request blocking** panel (which opens automatically when you block a request) to add, edit and remove URLs or URL patterns
 
-![Screenshot of the Network panel in Edge showing the contextual menu with the "block request url" item](/assets/img/block-resources-1.png)
+![The Network panel in Edge showing the contextual menu with the "block request url" item.](/assets/img/block-resources-1.png)
 
 * With Firefox:
   * Go to the **Network** panel
@@ -24,4 +24,4 @@ With DevTools you can block individual URLs or more global patterns.
   * Reload the page
   * You can also use the **Blocking** sidebar (which opens automatically when you block a request) to add, edit and remove URLs or URL patterns
 
-![Screenshot of the Network panel in Firefox showing the contextual menu with the "block url" item and the "blocking" sidebar](/assets/img/block-resources-2.png)
+![The Network panel in Firefox showing the contextual menu with the "block url" item and the "blocking" sidebar.](/assets/img/block-resources-2.png)

--- a/src/tips/en/break-on-dom-changes.md
+++ b/src/tips/en/break-on-dom-changes.md
@@ -19,6 +19,6 @@ To add a DOM breakpoint:
 * Open the contextual menu (right-click).
 * Open the **Break on** sub menu and choose the type of breakpoint you want to set.
 
-![Screenshot of the Elements panel in Edge showing the "Break on" contextual menu on the selected node](/assets/img/break-on-dom-changes.png)
+![The Elements panel in Edge showing the "Break on" contextual menu on the selected node.](/assets/img/break-on-dom-changes.png)
 
 Once the requested DOM modification occurs, the JavaScript execution will pause and DevTools will navigate to the Sources/Debugger panel, showing the right line of code where execution is paused.

--- a/src/tips/en/capture-node-creation-stacks.md
+++ b/src/tips/en/capture-node-creation-stacks.md
@@ -20,4 +20,4 @@ It turns out there is a way to do this automatically without having to set break
   * In the sidebar, select the **Stack Trace** panel (you might have to first click on the **More tabs** chevron `>>` to see the tab)
   * The stack of JavaScript calls that led to the node creation (if any) should be displayed.
 
-![Screenshot of Edge DevTools' Elements panel with the Stack Trace sidebar visible, showing a stack of Vue JS function calls that created an element on the TODOMVC sample app](/assets/img/capture-node-creation-stacks.png)
+![Edge DevTools' Elements panel with the Stack Trace sidebar visible, showing a stack of Vue JS function calls that created an element on the TODOMVC sample app.](/assets/img/capture-node-creation-stacks.png)

--- a/src/tips/en/change-color-theme.md
+++ b/src/tips/en/change-color-theme.md
@@ -15,4 +15,4 @@ You can change the theme based on your preference.
 * In Safari
   * Go to the settings and select "Appearance" between "System", "Light" or "Dark"
 
-![Screenshot of the settings panel in Edge showing the Theme drop-down](/assets/img/change-color-theme.png)
+![the settings panel in Edge showing the Theme drop-down.](/assets/img/change-color-theme.png)

--- a/src/tips/en/check-bfcache-readiness.md
+++ b/src/tips/en/check-bfcache-readiness.md
@@ -18,4 +18,4 @@ To test if your page can be cached:
 
 A report will be displayed, telling you whether your page can be cached, and if not, why.
 
-![Screenshot of Chrome DevTools with the Application tool, and the bfcache tab selected, showing a warning that the page can't be cached](/assets/img/check-bfcache-readiness.png)
+![Chrome DevTools with the Application tool, and the bfcache tab selected, showing a warning that the page can't be cached.](/assets/img/check-bfcache-readiness.png)

--- a/src/tips/en/convert-color-formats.md
+++ b/src/tips/en/convert-color-formats.md
@@ -11,4 +11,4 @@ In DevTools, you can easily convert from one format to the next.
 * Find an element in the **Elements** panel (or **Inspector** panel in Firefox) that has some CSS color properties applied.
 * In the **Styles** panel (or **Rules** in Firefox), hold **Shift** and click on the color swatch (the little colored circle next to the color value) to cycle through the different formats.
 
-![Gif animation of the rules panel in Firefox, showing the color conversion](/assets/img/convert-color-formats.gif)
+![Animation of the rules panel in Firefox, showing the color conversion.](/assets/img/convert-color-formats.gif)

--- a/src/tips/en/convert-font-units.md
+++ b/src/tips/en/convert-font-units.md
@@ -6,14 +6,14 @@ tags: ["css", "browser:edge", "browser:chrome", "browser:firefox"]
 ---
 Font CSS properties such as `font-size`, `line-height` or `letter-spacing` can be expressed in multiple different length units (like many other CSS properties).
 
-Firefox, Chrome and Edge allow you to convert values between these units easily. 
+Firefox, Chrome and Edge allow you to convert values between these units easily.
 
 * In Firefox
   * Find an element in the Inspector panel that has font properties which you'd like to change
   * Select the Fonts sidebar tab
   * Use the unit drop-downs next to `Size`, `Line Height` or `Spacing` to convert the current value to another unit
 
-![Screenshot of the fonts panel in Firefox, showing the unit conversion drop-down](/assets/img/convert-font-units-1.png)
+![The fonts panel in Firefox, showing the unit conversion drop-down.](/assets/img/convert-font-units-1.png)
 
 * In Chrome or Edge
   * You first need to enable the Fonts editor experiment
@@ -25,4 +25,4 @@ Firefox, Chrome and Edge allow you to convert values between these units easily.
   * Click on the `Aa` icon in the Styles sidebar, in the CSS rule that contains the property you want to convert
   * Use the unit drop-downs next to `Font Size`, `Line Height`, `Font Weight` or `Spacing` to convert the current value to another unit
 
-![Screenshot of the fonts panel in Edge, showing the unit conversion drop-down](/assets/img/convert-font-units-2.png)
+![The fonts panel in Edge, showing the unit conversion drop-down.](/assets/img/convert-font-units-2.png)

--- a/src/tips/en/copy-css-selector.md
+++ b/src/tips/en/copy-css-selector.md
@@ -19,4 +19,4 @@ This will copy the CSS selector for the element, which can then be used in JavaS
   <h2>104 DevTools Tips</h2>
 ```
 
-![Screenshot of Edge DevTools, showing how to access the Copy CSS selector option](/assets/img/copy-css-selector.png)
+![Edge DevTools, showing how to access the Copy CSS selector option.](/assets/img/copy-css-selector.png)

--- a/src/tips/en/copy-element-js-path.md
+++ b/src/tips/en/copy-element-js-path.md
@@ -12,4 +12,4 @@ To automatically get the right JavaScript expression to use for any node:
 1. Right-click the node and select **Copy** > **Copy JS path**.
 1. The right `document.querySelector()` expression is now in your clipboard. You can paste it anywhere you need it.
 
-![Screenshot of the Elements tool in Edge showing the context menu on an element, with the Copy JS path option](/assets/img/copy-element-js-path.png)
+![The Elements tool in Edge showing the context menu on an element, with the Copy JS path option.](/assets/img/copy-element-js-path.png)

--- a/src/tips/en/copy-element-styles.md
+++ b/src/tips/en/copy-element-styles.md
@@ -14,7 +14,7 @@ No need to go through all CSS rules and properties that apply to the element in 
 1. Click **Copy** > **Copy styles**.
 1. Paste the result in a text editor and use however you want.
 
-![Screenshot of the Edge DevTools Elements panel, showing the context menu on an element and the Copy styles menu item. The screenshot also shows what the result of copying styles is: a flat list of CSS properties and values.](/assets/img/copy-element-styles.png)
+![The Edge DevTools Elements panel, showing the context menu on an element and the Copy styles menu item. The screenshot also shows what the result of copying styles is: a flat list of CSS properties and values.](/assets/img/copy-element-styles.png)
 
 In Polypane,
 

--- a/src/tips/en/copy-element-xpath.md
+++ b/src/tips/en/copy-element-xpath.md
@@ -13,4 +13,4 @@ You can easily copy an element's [XPath](https://developer.mozilla.org/en-US/doc
 
 Note that you can then use this xpath expression to [find elements again in DevTools](/tips/en/evaluate-xpath/).
 
-![Screenshot of the Elements panel in Edge showing the copy xpath option in the contextual menu](/assets/img/copy-element-xpath.png)
+![The Elements panel in Edge showing the copy xpath option in the contextual menu.](/assets/img/copy-element-xpath.png)

--- a/src/tips/en/copy-from-console.md
+++ b/src/tips/en/copy-from-console.md
@@ -8,4 +8,4 @@ The console panel supports a very handy `copy()` function that stringifies and c
 
 For example: `copy($$('a').map(a => a.href).join('\n'))` copies all of the links from the page.
 
-![Screenshot of Chrome devtools' console with a line of code using the copy() function](/assets/img/copy-from-console.png)
+![Chrome devtools' console with a line of code using the copy() function.](/assets/img/copy-from-console.png)

--- a/src/tips/en/copy-rule-as-css-in-js.md
+++ b/src/tips/en/copy-rule-as-css-in-js.md
@@ -37,7 +37,7 @@ In Edge and Chrome, you don't have to. They both have an option that does the re
 
 Note that you can also use **Copy declaration as JS** if you only want one. But this feature really shines when you copy all declarations at once.
 
-![GIF showing the Styles pane in Edge, with the "Copy all declarations as JS" option being used, and then pasting the result in the Console to show that it is formatted](/assets/img/copy-rule-as-css-in-js.gif)
+![Aimation showing the Styles pane in Edge, with the "Copy all declarations as JS" option being used, and then pasting the result in the Console to show that it is formatted.](/assets/img/copy-rule-as-css-in-js.gif)
 
 Find out more about this feature on [the Microsoft DevTools docs website](https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/css/css-in-js), or take a look at this short screencast:
 

--- a/src/tips/en/customize-keyboard-shortcuts.md
+++ b/src/tips/en/customize-keyboard-shortcuts.md
@@ -22,4 +22,4 @@ To customize the shortcuts:
 1. Press the new key combination you want for this shortcut.
 1. You can then save the new shortcut, cancel your change, or revert to the shortcut's initial value.
 
-![The Settings panel in Microsoft Edge, showing the keyboard shortcut customization screen](/assets/img/customize-keyboard-shortcuts.png)
+![The Settings panel in Microsoft Edge, showing the keyboard shortcut customization screen.](/assets/img/customize-keyboard-shortcuts.png)

--- a/src/tips/en/debug-css-cascade-layers.md
+++ b/src/tips/en/debug-css-cascade-layers.md
@@ -18,7 +18,7 @@ Safari, Firefox, Chrome, Polypane and Edge all have support for layers in their 
 1. In the sidebar where CSS rules are displayed, rules are sorted by cascade layers, with the highest priority layers at the top, and lowest priority at the bottom.
 1. Rules that are part of a cascade layer have a `@layer <layername>` label above them.
 
-![Screenshot of Firefox, with a demo page that uses layers and devtools opened, showing the Rules panel with 2 @layer rules](/assets/img/debug-css-cascade-layers-firefox.png)
+![Firefox showing a demo page that uses layers and devtools opened, showing the Rules panel with 2 @layer rules.](/assets/img/debug-css-cascade-layers-firefox.png)
 
 ### Only Edge and Chrome
 
@@ -28,4 +28,4 @@ On top of the above, Edge and Chrome have a layers view:
 1. Inspect an element which has styles defined in one of the cascade layers like one of the green links in the above demo.
 1. Click **Toggle CSS layers view** in the **Styles** panel toolbar (next to the search field) to reveal the list of layers.
 
-![Screenshot of Edge, with a demo page that uses layers and devtools opened, showing the Rules panel with 2 @layer rules and the layers view](/assets/img/debug-css-cascade-layers-edge.png)
+![Edge showing a demo page that uses layers and devtools opened, showing the Rules panel with 2 @layer rules and the layers view.](/assets/img/debug-css-cascade-layers-edge.png)

--- a/src/tips/en/debug-grid-areas.md
+++ b/src/tips/en/debug-grid-areas.md
@@ -23,4 +23,4 @@ DevTools in Firefox, Chrome, and Edge make it very easy to debug potential probl
 * Go to the **Layout** sidebar pane.
 * Under the **Grid** section, check the **Show area names** box.
 
-![Screenshot of Firefox, with a highlighted grid in the page showing the area names, and devtools below it with the "display area names" option checked](/assets/img/debug-grid-areas.png)
+![Firefox showing a highlighted grid in the page showing the area names, and devtools below it with the "display area names" option checked.](/assets/img/debug-grid-areas.png)

--- a/src/tips/en/debug-js-hover.md
+++ b/src/tips/en/debug-js-hover.md
@@ -13,7 +13,7 @@ Have you ever been frustrated because you couldn't style a popup or tooltip that
 
 That's it! The JS engine will pause and freeze the state of the page. You can now switch back to **Elements**/**Inspector** and style the popup content!
 
-![GIF showing how to pause the debugger with F8 while a tooltip is visible to then style it in the Inspector panel of Firefox](/assets/img/debug-js-hover.gif)
+![Animation showing how to pause the debugger with F8 while a tooltip is visible to then style it in the Inspector panel of Firefox.](/assets/img/debug-js-hover.gif)
 
 Thank you to [Sam Selikoff](https://twitter.com/samselikoff) for [tweeting](https://twitter.com/samselikoff/status/1441142046492807176) about this tip and making a youtube video about it too:
 

--- a/src/tips/en/debug-unwanted-scrollbars.md
+++ b/src/tips/en/debug-unwanted-scrollbars.md
@@ -13,11 +13,11 @@ All very good questions that can cause a lot of time lost and frustration.
 
 In the **Inspector** panel, where the DOM tree of the page is displayed, you will notice **scroll** badges next to all elements that have scrollbars!
 
-![Screenshot of Firefox DevTools, with the Inspector panel showing the Scroll badge on an element](/assets/img/debug-unwanted-scrollbars-1.png)
+![Firefox DevTools, with the Inspector panel showing the Scroll badge on an element.](/assets/img/debug-unwanted-scrollbars-1.png)
 
 This takes care of our first question: which element is scrolling? As for the second question: which elements are causing the scrolling, if you just click on one of the **scroll** badges, the **Inspector** will jump to the element (or elements) that caused the scrollbars to appear and highlight them for you!
 
-![Screenshot of Firefox DevTools, with the Inspector panel showing the Overflow badge on 3 highlighted elements](/assets/img/debug-unwanted-scrollbars-2.png)
+![Firefox DevTools, with the Inspector panel showing the Overflow badge on 3 highlighted elements.](/assets/img/debug-unwanted-scrollbars-2.png)
 
 Now this feature won't answer our third question: Why are these elements too big? But once you know which elements are the root cause of the problem, you can use the **Rules** siderbar pane to figure out which CSS properties are responsible for it.
 
@@ -27,11 +27,11 @@ Now this feature won't answer our third question: Why are these elements too big
 
 When a page has a horizontal scrollbar, Polypane will display an **Overflow icon** below it. This will tell you why there is a horizontal overflow: either there are elements that are too wide or there is a `100vw` applied to the page.
 
-![Screenshot of Polypane, with an overflow icon below a Pane. The text in the tooltip reads "Horizontal overflow detected!"](/assets/img/debug-unwanted-scrollbars-3.png)
+![Polypane, with an overflow icon below a Pane. The text in the tooltip reads "Horizontal overflow detected!".](/assets/img/debug-unwanted-scrollbars-3.png)
 
 After clicking the icon, Polypane finds the elements causing an overflow in your page and highlights them in red.
 
-![Screenshot of Polypane showing a page. A single element is highlighted in red and is clearly expanding beyond the edge."](/assets/img/debug-unwanted-scrollbars-4.png)
+![Polypane showing a page. A single element is highlighted in red and is clearly expanding beyond the edge".](/assets/img/debug-unwanted-scrollbars-4.png)
 
 From here, you can inspect the element and find the cause of the problem.
 

--- a/src/tips/en/debugger-statement.md
+++ b/src/tips/en/debugger-statement.md
@@ -11,4 +11,4 @@ If you prefer to use `console.log()` statements rather than the JavaScript debug
 * Trigger the action that will make your code run
 * The Sources panel (or Debugger panel in Firefox) will automatically open up, and pause script execution at that line, giving you a chance to see what are the values of local variables, the callstack, etc.
 
-![Screenshot of the Sources panel in Edge, paused at a debugger statement](/assets/img/debugger-statement.png)
+![The Sources panel in Edge, paused at a debugger statement.](/assets/img/debugger-statement.png)

--- a/src/tips/en/detect-low-color-contrast.md
+++ b/src/tips/en/detect-low-color-contrast.md
@@ -17,14 +17,14 @@ DevTools comes with a number of features to help you detect possible color contr
   * Click **Capture overview**.
   * Click the **Colors** tab in the sidebar and scroll down to the **Contrast issues** section.
 
-  ![Screenshot of the CSS Overview panel in Chrome, showing the color contrast issues section](/assets/img/detect-low-color-contrast-css-overview.png)
+  ![The CSS Overview panel in Chrome, showing the color contrast issues section.](/assets/img/detect-low-color-contrast-css-overview.png)
 
 * In Firefox, you can find all contrast issues too, using the **Accessibility** panel.
   * Open the **Accessibility** panel from the toolbar.
   * In the **Check for issues** drop-down, select **Contrast**.
   * Click each item in the table and review the color contrast ratio.
 
-  ![Screenshot of the Accessibility panel in Firefox, showing the list of contrast issues](/assets/img/detect-low-color-contrast-accessibility-panel.png)
+  ![The Accessibility panel in Firefox, showing the list of contrast issues.](/assets/img/detect-low-color-contrast-accessibility-panel.png)
 
 * In Polypane, you can find all contrast issues with the **Color Contrast debug tool**.
   * Open the **Debug Tools** settings of a pane.
@@ -32,4 +32,4 @@ DevTools comes with a number of features to help you detect possible color contr
   * Select whether you want to check for WCAG **AA** or **AAA** compliance.
   * Contrast issues are displayed inline on the page. Where available, Polypane suggests improved colors.
 
-  ![Screenshot of a Polypane Pane with the Contrast checker debug tool active](/assets/img/detect-low-color-contrast-inline.png)
+  ![A Polypane Pane with the Contrast checker debug tool active.](/assets/img/detect-low-color-contrast-inline.png)

--- a/src/tips/en/disable-event-listeners.md
+++ b/src/tips/en/disable-event-listeners.md
@@ -16,7 +16,7 @@ In Firefox, you can disable (and re-enable) events from the **Inspector** panel:
 * Find the event type you are interested in.
 * Check or uncheck the box next to the event listener to enable or disable it.
 
-![Screenshot of the Firefox event popup in the Inspector panel, showing the checkbox to toggle events](/assets/img/disable-event-listeners-firefox.png)
+![The Firefox event popup in the Inspector panel, showing the checkbox to toggle events.](/assets/img/disable-event-listeners-firefox.png)
 
 In Chrome and Edge, you can remove events from the **Elements** panel (but not add them again):
 
@@ -25,4 +25,4 @@ In Chrome and Edge, you can remove events from the **Elements** panel (but not a
 * Find the event type you are interested in and expand it.
 * Click the **Remove** button next to the listener you want to remove.
 
-![Screenshot of the Chrome Event Listeners sidebar pane, showing the Remove button](/assets/img/disable-event-listeners-chrome.png)
+![The Chrome Event Listeners sidebar pane, showing the Remove button.](/assets/img/disable-event-listeners-chrome.png)

--- a/src/tips/en/download-all-images.md
+++ b/src/tips/en/download-all-images.md
@@ -10,7 +10,7 @@ If you want to download all of the images on a webpage in one go, you can use th
 $$('img').forEach(async (img) => {
   try {
     const src = img.src;
-    
+
     // Fetch the image as a blob.
     const fetchResponse = await fetch(src);
     const blob = await fetchResponse.blob();
@@ -22,7 +22,7 @@ $$('img').forEach(async (img) => {
     let name = src.substring(start, end === -1 ? undefined : end);
     name = name.replace(/[^a-zA-Z0-9]+/g, '-');
     name += '.' + mimeType.substring(mimeType.lastIndexOf('/') + 1);
-    
+
     // Download the blob using a <a> element.
     const a = document.createElement('a');
     a.setAttribute('href', URL.createObjectURL(blob));
@@ -36,4 +36,4 @@ This will list all of the `img` elements on the page, then attempt to fetch them
 
 If you want to reuse this script often, you can store it in your **Snippets** on Chrome or Edge (learn how to do it [here](/tips/en/multi-line-console)).
 
-![Screenshot of the Snippets panel in Edge, with the JS code from above, and the download panel open showing all images have been downloaded](/assets/img/download-all-images.png)
+![The Snippets panel in Edge, with the JS code from above, and the download panel open showing all images have been downloaded].(/assets/img/download-all-images.png)

--- a/src/tips/en/drag-drop-dom-nodes.md
+++ b/src/tips/en/drag-drop-dom-nodes.md
@@ -6,4 +6,4 @@ tags: ["html", "browser:edge", "browser:chrome", "browser:firefox", "browser:saf
 ---
 If you need to move nodes or elements around in the DOM tree, to re-order things in the page, you can do it by drag and dropping nodes around in the Elements (or Inspector) panel.
 
-![Gif animation showing a node being dragged by the mouse in the DOM tree view of the Elements panel in Edge](/assets/img/drag-drop-dom-nodes.gif)
+![Animation showing a node being dragged by the mouse in the DOM tree view of the Elements panel in Edge.](/assets/img/drag-drop-dom-nodes.gif)

--- a/src/tips/en/edit-and-resend-network-requests.md
+++ b/src/tips/en/edit-and-resend-network-requests.md
@@ -28,7 +28,7 @@ Firefox has a built-in **Edit and Resend** feature that's very convenient becaus
 * In the new panel that appears, you can edit the request's method, url, query string, headers, and body.
 * Press **Send** when you're happy with the values.
 
-![Screenshot of the Firefox's edit and resend feature](/assets/img/edit-and-resend-network-requests-firefox.png)
+![The Firefox's edit and resend feature.](/assets/img/edit-and-resend-network-requests-firefox.png)
 
 ### Using Edge's Network Console experiment
 
@@ -43,4 +43,4 @@ The feature is called **Network Console** and is an experiment for the time bein
 * Press **Send** when you're happy with the values.
 * You can also save this request for later. You can find all saved requests in the **Network Console** panel.
 
-![Screenshot of the Edge's Network Console feature](/assets/img/edit-and-resend-network-requests-edge.png)
+![The Edge's Network Console feature.](/assets/img/edit-and-resend-network-requests-edge.png)

--- a/src/tips/en/edit-clip-path-shape-outside.md
+++ b/src/tips/en/edit-clip-path-shape-outside.md
@@ -18,4 +18,4 @@ In Firefox, you can freely edit the polygon, circle or ellipse types of shapes w
 
 [Learn more about this tool here](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes)
 
-![Gif demo of the shape editor in firefox, clicking on the Rules panel icon, and then moving points around in the page](/assets/img/edit-clip-path-shape-outside.gif)
+![Animation of the shape editor in firefox, clicking on the Rules panel icon, and then moving points around in the page.](/assets/img/edit-clip-path-shape-outside.gif)

--- a/src/tips/en/edit-css-angles.md
+++ b/src/tips/en/edit-css-angles.md
@@ -8,4 +8,4 @@ In CSS, several different properties use [angle](https://developer.mozilla.org/e
 
 In Chrome and Edge, wherever a value that uses an angle unit (e.g. `deg`, `rad`, `grad`, `turn`) is displayed in the Styles panel, you can edit it with a nice little visual editor instead of typing the number by hand.
 
-![Gif animation of the angle editor in Chrome, where a click is made on the angle swatch, and then the mouse is used to change the angle](/assets/img/edit-css-angles.gif)
+![Animation of the angle editor in Chrome, where a click is made on the angle swatch, and then the mouse is used to change the angle.](/assets/img/edit-css-angles.gif)

--- a/src/tips/en/edit-css-filters.md
+++ b/src/tips/en/edit-css-filters.md
@@ -13,4 +13,4 @@ Firefox provides a visual editor to play with CSS filters. You can add or remove
 
 [Learn more on MDN](https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_CSS_filters).
 
-![Screenshot of the filter editing UI in Firefox](/assets/img/edit-css-filters.png)
+![The filter editing UI in Firefox.](/assets/img/edit-css-filters.png)

--- a/src/tips/en/edit-elements-with-the-keyboard.md
+++ b/src/tips/en/edit-elements-with-the-keyboard.md
@@ -14,4 +14,4 @@ To do this, select an element in the **Elements** tool (called **Inspector** in 
   * Either press <kbd>Enter</kbd> again to commit the change.
   * Or, press <kbd>Tab</kbd> or <kbd>Shift</kbd>+<kbd>Tab</kbd> to move to the next or previous attribute, or the tag name if there are no other attributes.
 
-![GIF animation of a part of the Inspector panel in Firefox, showing how pressing Enter on a focused element goes into edit mode and how Tab allows to navigate from field to field](/assets/img/edit-elements-with-the-keyboard.gif)
+![Animation of a part of the Inspector panel in Firefox, showing how pressing Enter on a focused element goes into edit mode and how Tab allows to navigate from field to field.](/assets/img/edit-elements-with-the-keyboard.gif)

--- a/src/tips/en/edit-javascript-while-debugging.md
+++ b/src/tips/en/edit-javascript-while-debugging.md
@@ -23,4 +23,4 @@ Now in Chromium-based browsers, you can test those quick fixes much faster witho
 
 This means you don't need to leave DevTools, make your change to the original code, reload the page, and wait to hit the breakpoint or error again!
 
-![GIf animation showing that it is possible to write code in the Sources panel, while debugging, to test fixes](/assets/img/edit-javascript-while-debugging.gif)
+![Animation showing that it is possible to write code in the Sources panel, while debugging, to test fixes.](/assets/img/edit-javascript-while-debugging.gif)

--- a/src/tips/en/edit-position.md
+++ b/src/tips/en/edit-position.md
@@ -13,4 +13,4 @@ Firefox features a position editor that lets you move elements in the page by dr
 
 [Learn more about this tool here](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Reposition_elements_in_the_page)
 
-![Gif demo of the geometry editor in firefox, toggling it from the Layout panel, and then dragging top and left points to move the element in the page](/assets/img/edit-position.gif)
+![Animation of the geometry editor in Firefox, toggling it from the Layout panel, and then dragging top and left points to move the element in the page.](/assets/img/edit-position.gif)

--- a/src/tips/en/edit-shadow.md
+++ b/src/tips/en/edit-shadow.md
@@ -10,4 +10,4 @@ If you don't remember the CSS syntax for the `box-shadow` property (and who does
 * Go to the **Styles** pane.
 * Click on the little shadow editor icon next to the `box-shadow` property value.
 
-![GIF animation showing the shadow editor in Edge's Styles pane](/assets/img/edit-shadow.gif)
+![Animation showing the shadow editor in Edge's Styles pane.](/assets/img/edit-shadow.gif)

--- a/src/tips/en/empty-cache-refresh.md
+++ b/src/tips/en/empty-cache-refresh.md
@@ -10,4 +10,4 @@ Here is a nice tip to quickly empty your cache and refresh the page, in order to
 * Right-click on the page refresh icon, in the browser toolbar.
 * Click **Empty cache and hard refresh**.
 
-![Screenshot of the Microsoft Edge browser toolbar, showing the contextual menu of the refresh button, with the empty cache and hard refresh menu item](/assets/img/empty-cache-refresh.png)
+![The Microsoft Edge browser toolbar, showing the contextual menu of the refresh button, with the empty cache and hard refresh menu item.](/assets/img/empty-cache-refresh.png)

--- a/src/tips/en/emulate-forced-colors.md
+++ b/src/tips/en/emulate-forced-colors.md
@@ -18,7 +18,7 @@ In Edge or Chrome:
 - Type **Rendering** and press <kbd>Enter</kbd>.
 - In the **Rendering** panel, scroll down to the **Emulate CSS media feature forced-colors** and activate it from the drop-down.
 
-![Screenshot of Edge showing a webpage in forced-colors mode, with the Rendering panel next to it in DevTools](/assets/img/emulate-forced-colors.png)
+![Edge showing a webpage in forced-colors mode, with the Rendering panel next to it in DevTools.](/assets/img/emulate-forced-colors.png)
 
 In Polypane:
 
@@ -26,4 +26,4 @@ In Polypane:
 - Toggle **Forced colors**.
 - (Optionally) Toggle the `prefers-color-scheme` to test both a light and dark forced color mode.
 
-![Screenshot of Polypane showing a webpage in forced-colors mode, with the Emulation options opened above it, the "forced colors" option is active and highlighted](/assets/img/emulate-forced-colors-polypane.png)
+![Polypane showing a webpage in forced-colors mode, with the Emulation options opened above it, the "forced colors" option is active and highlighted.](/assets/img/emulate-forced-colors-polypane.png)

--- a/src/tips/en/emulate-idle-detection-states.md
+++ b/src/tips/en/emulate-idle-detection-states.md
@@ -17,6 +17,6 @@ Thankfully, Chrome has a nice little feature in its DevTools to emulate various 
 * Scroll down and look for the **Emulate Idle Detector state** section.
 * Choose one of the states to test if your code does what it's supposed to.
 
-![Chrome DevTools' Sensors panel, showing a drop-down list with the different states that can be emulated](/assets/img/emulate-idle-detection-states.png)
+![Chrome DevTools' Sensors panel, showing a drop-down list with the different states that can be emulated.](/assets/img/emulate-idle-detection-states.png)
 
 [Learn more about the Idle Detection API and the corresponding DevTools support](https://developer.chrome.com/articles/idle-detection/#devtools-support).

--- a/src/tips/en/evaluate-xpath.md
+++ b/src/tips/en/evaluate-xpath.md
@@ -11,7 +11,7 @@ DevTools supports 2 ways to evaluate [XPath](https://developer.mozilla.org/en-US
   * Press <kbd>ctrl</kbd>+<kbd>F</kbd> (or <kbd>cmd</kbd>+<kbd>F</kbd> on Mac) to focus the search field
   * Enter your XPath expression and press enter to find the elements that match
 
-![Screenshot of the Inspector panel in Firefox showing the search field with an XPath expression](/assets/img/evaluate-xpath-1.png)
+![The Inspector panel in Firefox showing the search field with an XPath expression.](/assets/img/evaluate-xpath-1.png)
 
 Note that you can also [copy the XPath expression from any element in DevTools](/tips/en/copy-element-xpath/).
 
@@ -22,4 +22,4 @@ Note that you can also [copy the XPath expression from any element in DevTools](
 $x('//div/div/label');
 ```
 
-![Screenshot of the Console panel in Safari showing an array of elements, as the result of executing the above function](/assets/img/evaluate-xpath-2.png)
+![The Console panel in Safari showing an array of elements, as the result of executing the above function.](/assets/img/evaluate-xpath-2.png)

--- a/src/tips/en/execute-commands.md
+++ b/src/tips/en/execute-commands.md
@@ -10,4 +10,4 @@ Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>P</kbd> (or <kbd>cmd</kbd>+<kbd>shif
 
 You can use this to, for example, switch to a different panel by typing its name, change the color theme, change settings, disable javascript, etc.
 
-![Screenshot of Edge's command menu](/assets/img/execute-commands.png)
+![Edge's command menu.](/assets/img/execute-commands.png)

--- a/src/tips/en/expand-nodes-recursively.md
+++ b/src/tips/en/expand-nodes-recursively.md
@@ -12,4 +12,4 @@ You can expand all descendants under a given DOM node in one go, to avoid having
   * Right-click on the node you want to expand and select "Expand All". You can also `alt+click` or `option+click` on the arrow next to the node.
 
 
-![GIF animation showing right-clicking on a node in Chrome's Elements panel and choosing "expand recursively"](/assets/img/expand-nodes-recursively.gif)
+![Animation showing right-clicking on a node in Chrome's Elements panel and choosing "expand recursively".](/assets/img/expand-nodes-recursively.gif)

--- a/src/tips/en/extend-devtools.md
+++ b/src/tips/en/extend-devtools.md
@@ -19,4 +19,4 @@ To go further, you can create your own extensions. Here are a few links to learn
 * [Extending the developer tools](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools) on MDN.
 * [Adding a web development tool to Safari Web Inspector](https://developer.apple.com/documentation/safariservices/safari_web_extensions/adding_a_web_development_tool_to_safari_web_inspector) on developer.apple.com.
 
-![Microsoft Edge, with DevTools opened, showing a custom panel](/assets/img/extend-devtools.png)
+![Microsoft Edge, with DevTools opened, showing a custom panel.](/assets/img/extend-devtools.png)

--- a/src/tips/en/filter-network-requests.md
+++ b/src/tips/en/filter-network-requests.md
@@ -11,4 +11,4 @@ The Network panel lets you filter requests by status code, or mime type, and mor
 * Other possible filters include `mime-type`, `domain`, `larger-than`, `method`, and more.
 * You can also negate the search by putting a `-` in front (e.g. `-status-code:404`).
 
-![Screenshot of the Network panel in Edge showing the filter input field](/assets/img/filter-network-requests.png)
+![The Network panel in Edge showing the filter input field.](/assets/img/filter-network-requests.png)

--- a/src/tips/en/find-all-images-without-alt-text.md
+++ b/src/tips/en/find-all-images-without-alt-text.md
@@ -10,7 +10,7 @@ Using DevTools, you can quickly check which images on a page do not have an `alt
 
 Execute this in the Console panel: `console.table($$('img').filter(i => !i.alt), ['src'])` and that's it! You'll have the list of image URLs that don't have an alternative text.
 
-![The output of the console.table command from above shown in the Firefox DevTools console](/assets/img/find-all-images-without-alt-text.png)
+![The output of the console.table command from above shown in the Firefox DevTools console.](/assets/img/find-all-images-without-alt-text.png)
 
 Here's what this command does:
 

--- a/src/tips/en/find-css-changes.md
+++ b/src/tips/en/find-css-changes.md
@@ -11,4 +11,4 @@ If you spent time changing CSS in DevTools, either in the Rules panel (in Firefo
 * In Chrome or Edge:
   * The Changes panel (which you can open from the command menu by typing <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>P</kbd> or <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>P</kbd>)
 
-![Screenshot of the Changes panel in Firefox showing a diff-like view of all the CSS changes](/assets/img/find-css-changes.png)
+![The Changes panel in Firefox showing a diff-like view of all the CSS changes.](/assets/img/find-css-changes.png)

--- a/src/tips/en/find-custom-elements-code.md
+++ b/src/tips/en/find-custom-elements-code.md
@@ -6,4 +6,4 @@ tags: ["webcomponents", "javascript", "browser:firefox"]
 ---
 In Firefox, when inspecting elements (in the Inspector panel), you can click on the `custom` badge to go straight to the custom element's JavaScript source code.
 
-![Gif animation showing the custom button in Firefox's inspector and that clicking on it goes to the debugger](/assets/img/find-custom-elements-code.gif)
+![Animation showing the custom button in Firefox's inspector and that clicking on it goes to the debugger.](/assets/img/find-custom-elements-code.gif)

--- a/src/tips/en/find-devtools-documentation.md
+++ b/src/tips/en/find-devtools-documentation.md
@@ -12,4 +12,4 @@ If you want to learn more about what other tools exist in a browser, or what fea
 * [Safari Web Inspector](https://webkit.org/web-inspector/)
 * [Polypane developer tools](https://polypane.app/docs/)
 
-![Screenshot of the 4 documentation websites listed above](/assets/img/find-devtools-documentation.png)
+![The 4 documentation websites listed above.](/assets/img/find-devtools-documentation.png)

--- a/src/tips/en/find-expensive-selectors.md
+++ b/src/tips/en/find-expensive-selectors.md
@@ -24,4 +24,4 @@ Microsoft Edge has a very useful new feature starting with Edge version 110 call
 
 You now have access to the list of CSS selectors that got matched against the DOM tree of the web page during this style recalculation task. You can sort the table by elapsed time or match count to get an understanding of which selectors needed the most time to run.
 
-![The Edge DevTools Performance tool, showing a recorded profile with a selected Recalculate Style block, and the Selector Stats table below it](/assets/img/find-expensive-selectors.png)
+![The Edge DevTools Performance tool, showing a recorded profile with a selected Recalculate Style block, and the Selector Stats table below it.](/assets/img/find-expensive-selectors.png)

--- a/src/tips/en/find-html-parsing-errors.md
+++ b/src/tips/en/find-html-parsing-errors.md
@@ -27,6 +27,6 @@ Consider the following HTML code:
 
 Firefox's view-source makes it easy to find the stray `</em>` ending tag! You can also hover over it to reveal more information about the type of parsing error.
 
-![Screenshot of the View-Source page in Firefox, with a stray em closing tag highlighted in red, with a tooltip](/assets/img/find-html-parsing-errors.png)
+![The View-Source page in Firefox, with a stray em closing tag highlighted in red, with a tooltip.](/assets/img/find-html-parsing-errors.png)
 
 Polypane additionally shows all validation errors in a list above the source.

--- a/src/tips/en/find-inactive-styles.md
+++ b/src/tips/en/find-inactive-styles.md
@@ -17,7 +17,7 @@ Firefox innovated with very cool feature that helps find these "inactive" CSS pr
 * Inactive properties are greyed out and have an information icon next to them.
 * Hover over the information icon to know why the property is inactive.
 
-![Part of the Rules panel in Firefox, showing a greyed out flex-grow property, with a tooltip saying that the property is inactive because the selected element is not a flex item](/assets/img/find-inactive-styles.png)
+![Part of the Rules panel in Firefox, showing a greyed out flex-grow property, with a tooltip saying that the property is inactive because the selected element is not a flex item.](/assets/img/find-inactive-styles.png)
 
 **In Chrome or Edge**:
 
@@ -30,6 +30,6 @@ Firefox innovated with very cool feature that helps find these "inactive" CSS pr
 * Inactive properties have an information icon next to them. If you see one, that means an authoring hint is available for this property.
 * Hover over the icon to reveal the tooltip with information about the property.
 
-![Part of the Styles panel in Chrome, showing a greyed out align-content property, with a tooltip saying that the property is inactive because the selected flex container is not set to wrap](/assets/img/find-inactive-styles-chromium.png)
+![Part of the Styles panel in Chrome, showing a greyed out align-content property, with a tooltip saying that the property is inactive because the selected flex container is not set to wrap.](/assets/img/find-inactive-styles-chromium.png)
 
 **Note**: this is not an audit tool! It won't help you remove useless CSS rules throughout your codebase. Its value is when inspecting specific elements only, to easily detect when a given CSS property isn't doing anything on it.

--- a/src/tips/en/fix-color-contrast-issues-with-element-tooltip.md
+++ b/src/tips/en/fix-color-contrast-issues-with-element-tooltip.md
@@ -14,7 +14,7 @@ Thanks to [Adam Argyle](https://twitter.com/argyleink) for [sharing this on Twit
 1. Position your mouse over the element which you are changing the color for. Don't click anywhere, we want to keep the color value field focused, just hover over the element so the element tooltip appears.
 1. Now change the color value with the keyboard and check the contrast ratio in the tooltip as you do so.
 
-![GIF animation of the Elements panel in Microsoft Edge. User clicks on color value, then activates the inspect tool, then hovers over an element on the page, then uses the arrow keys to change the color. We see the element tooltip showing the background and text colors as well as the resulting contrast.](/assets/img/fix-color-contrast-issues-with-element-tooltip.gif)
+![Animation of the Elements panel in Microsoft Edge. User clicks on color value, then activates the inspect tool, then hovers over an element on the page, then uses the arrow keys to change the color. We see the element tooltip showing the background and text colors as well as the resulting contrast.](/assets/img/fix-color-contrast-issues-with-element-tooltip.gif)
 
 Related tips:
 

--- a/src/tips/en/fix-color-contrast-issues.md
+++ b/src/tips/en/fix-color-contrast-issues.md
@@ -6,10 +6,10 @@ tags: ["accessibility", "browser:edge", "browser:chrome", "browser:polypane"]
 isTweet: true
 ---
 
-With DevTools you can [detect low color contrast issues](../detect-low-color-contrast) which is great. But DevTools in Chrome and Edge go one step further and help you fix these issues too! [Domi](https://twitter.com/domizajac) tells us all about it.
+With DevTools you can [detect low color contrast issues](../detect-low-color-contrast) which is great. But DevTools in Chrome, Polypane and Edge go one step further and help you fix these issues too! [Domi](https://twitter.com/domizajac) tells us all about it.
 
 https://twitter.com/domizajac/status/1507310081624444929
 
 In Polypane, these suggestions are made inline on the page itself when enabling the **Contrast checker debug tool**.
 
-![Screenshot of a Polypane Pane with the Contrast checker debug tool active](/assets/img/detect-low-color-contrast-inline.png)
+![A Polypane Pane with the Contrast checker debug tool active.](/assets/img/detect-low-color-contrast-inline.png)

--- a/src/tips/en/force-pwa-periodic-sync.md
+++ b/src/tips/en/force-pwa-periodic-sync.md
@@ -15,4 +15,4 @@ Thankfully, there is a way in Chrome and Edge to force the sync, so you don't ha
 * Scroll down to the **Periodic Sync** input.
 * Enter the tag name for your registered sync, and click the **Periodic Sync** button.
 
-![Screenshot of the Application panel in Edge showing the periodic sync input and buttons](/assets/img/force-pwa-periodic-sync.png)
+![The Application panel in Edge showing the periodic sync input and buttons.](/assets/img/force-pwa-periodic-sync.png)

--- a/src/tips/en/format-console-messages.md
+++ b/src/tips/en/format-console-messages.md
@@ -19,4 +19,4 @@ var el = document.body;
 console.log('%c There are %d elements in %O', 'color:lime;background:black;', el.childElementCount, el);
 ```
 
-![Screenshot of a formatted console message in Edge](/assets/img/format-console-messages.png)
+![A formatted console message in Edge.](/assets/img/format-console-messages.png)

--- a/src/tips/en/get-contextual-help.md
+++ b/src/tips/en/get-contextual-help.md
@@ -14,4 +14,4 @@ There are several ways to enable it:
 
 When tooltips are enabled, you can hover over them to get documentation about the tools.
 
-![gif animation of the devtools tooltips in edge](/assets/img/get-contextual-help.gif)
+![Animation of the devtools tooltips in Edge.](/assets/img/get-contextual-help.gif)

--- a/src/tips/en/get-current-element-in-console.md
+++ b/src/tips/en/get-current-element-in-console.md
@@ -10,6 +10,6 @@ This shortcut will return the DOM node instance, which you can then use to do th
 
 Example: `getComputedStyles($0).display`.
 
-![screenshot of safari's console showing how the $0 shortcut returns the selected elememt](/assets/img/get-current-element-in-console.jpg)
+![Safari's console showing how the $0 shortcut returns the selected element.](/assets/img/get-current-element-in-console.jpg)
 
 In Chrome, Polypane and Edge, the last 4 previously selected elements are additionally available as `$1`, `$2`, `$3` and `$4`. [Learn more here](/tips/en/get-current-element-in-console/).

--- a/src/tips/en/get-detached-elements.md
+++ b/src/tips/en/get-detached-elements.md
@@ -17,4 +17,4 @@ Edge has a tool just for this: the **Detached Elements** panel. To use it:
 
 You can find out much more about this tool in this [blog post](https://blogs.windows.com/msedgedev/2021/12/09/debug-memory-leaks-detached-elements-tool-devtools/) and over at Microsoft's [documentation](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks) site.
 
-![Screenshot of the Detached Elements panel in Edge, with the Memory panel next to it](/assets/img/get-detached-elements.png)
+![The Detached Elements panel in Edge, with the Memory panel next to it.](/assets/img/get-detached-elements.png)

--- a/src/tips/en/get-recently-selected-dom-nodes-in-console.md
+++ b/src/tips/en/get-recently-selected-dom-nodes-in-console.md
@@ -14,4 +14,4 @@ They can be used to access the recently selected DOM nodes:
 * `$2` returns the DOM node you selected before that.
 * And so on!
 
-![Chrome DevTools, with the Elements and Console tools shown. 5 DOM nodes are selected, one after the other, and then the $0, $1, $2, $3, and $4 shortcuts are used in the Console, showing how they refer to the previously selected DOM nodes](/assets/img/get-recently-selected-dom-nodes-in-console.gif)
+![Chrome DevTools, with the Elements and Console tools shown. 5 DOM nodes are selected, one after the other, and then the $0, $1, $2, $3, and $4 shortcuts are used in the Console, showing how they refer to the previously selected DOM nodes.](/assets/img/get-recently-selected-dom-nodes-in-console.gif)

--- a/src/tips/en/get-website-issues.md
+++ b/src/tips/en/get-website-issues.md
@@ -20,4 +20,4 @@ To see issues with the current page in Edge:
 
 [Learn more about this tool](https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/issues/).
 
-![Screenshot of the issues panel in Edge, showing many different issues about the page](/assets/img/get-website-issues.png)
+![The issues panel in Edge, showing many different issues about the page.](/assets/img/get-website-issues.png)

--- a/src/tips/en/hide-extension-resources.md
+++ b/src/tips/en/hide-extension-resources.md
@@ -8,4 +8,4 @@ If you want to hide scripts and other resources loaded by browser extensions in 
 
 Credits go to [Sunil](https://www.coolcomputerclub.com/) for his [post on twitter](https://twitter.com/threepointone/status/1446064032407080966).
 
-![Screenshot of the Network panel in Chrome DevTools showing the pattern used in the filter input box](/assets/img/hide-extension-resources.jpg)
+![The Network panel in Chrome DevTools showing the pattern used in the filter input box.](/assets/img/hide-extension-resources.jpg)

--- a/src/tips/en/highlight-css-properties-on-hover.md
+++ b/src/tips/en/highlight-css-properties-on-hover.md
@@ -14,4 +14,4 @@ Edge and Chrome help with this by highlighting the effect that individual CSS pr
 * Move your mouse cursor over it.
 * Watch as the corresponding affected region of the element gets highlighted in the page.
 
-![GIF animation showing a flex layout in the page, and the cursor moving over various properties in the Styles pane](/assets/img/highlight-css-properties-on-hover.gif)
+![Animation showing a flex layout in the page, and the cursor moving over various properties in the Styles pane.](/assets/img/highlight-css-properties-on-hover.gif)

--- a/src/tips/en/highlight-matching-elements.md
+++ b/src/tips/en/highlight-matching-elements.md
@@ -14,4 +14,4 @@ When you want to know which elements a given CSS rule will apply to, in addition
 * In Polypane:
   * In the Elements panel: Click the `[+]` icon next to each selector.
 
-![GIF animation showing how hovering over selectors in chrome highlights the matching elements in the page](/assets/img/highlight-matching-elements.gif)
+![Animation showing how hovering over selectors in chrome highlights the matching elements in the page.](/assets/img/highlight-matching-elements.gif)

--- a/src/tips/en/ignore-scripts.md
+++ b/src/tips/en/ignore-scripts.md
@@ -21,4 +21,4 @@ To ignore part of script only in Firefox:
 * Select the code you want to ignore.
 * Right-click the select and click **Ignore lines**.
 
-![Firefox ignore line contextual menu option, displayed on a few lines of selected JavaScript code](/assets/img/ignore-scripts.png)
+![Firefox ignore line contextual menu option, displayed on a few lines of selected JavaScript code.](/assets/img/ignore-scripts.png)

--- a/src/tips/en/increment-css-number-values.md
+++ b/src/tips/en/increment-css-number-values.md
@@ -17,4 +17,4 @@ In DevTools you can change numbers by using the arrow keys on your keyboard, thi
 * Or, hold <kbd>Alt</kbd> to increment by 0.1.
 * Or, hold <kbd>Ctrl</kbd> to increment by 100.
 
-![GIF animation of the Styles panel in Edge showing how numbers can be changed in various increments](/assets/img/increment-css-number-values.gif)
+![Animation of the Styles panel in Edge showing how numbers can be changed in various increments.](/assets/img/increment-css-number-values.gif)

--- a/src/tips/en/inspect-css-animations.md
+++ b/src/tips/en/inspect-css-animations.md
@@ -27,4 +27,4 @@ Next, trigger the animation to view its timeline in the **Animations** pane.
 
 Use the draggable vertical line to scrub through the timeline or jump to a specific point. You can also change the playback speed and do much [more](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/work_with_animations/index.html).
 
-![GIF of Chrome devtools showing how to inspect and modify CSS animations using the Animation inspector](/assets/img/inspect-css-animation.gif)
+![Animation of Chrome devtools showing how to inspect and modify CSS animations using the Animation inspector.](/assets/img/inspect-css-animation.gif)

--- a/src/tips/en/jump-to-css-variable.md
+++ b/src/tips/en/jump-to-css-variable.md
@@ -26,4 +26,4 @@ In Edge and Chrome, you can simply click on a `var(--foo)` function to jump to w
 * Click on the property name.
 * The Styles panel scrolls to where the property is defined and highlights it for a second.
 
-![GIF animation of clicking on a custom property link in the Styles panel in Edge](/assets/img/jump-to-css-variable.gif)
+![Animation of clicking on a custom property link in the Styles panel in Edge.](/assets/img/jump-to-css-variable.gif)

--- a/src/tips/en/jump-to-referenced-elements.md
+++ b/src/tips/en/jump-to-referenced-elements.md
@@ -23,6 +23,6 @@ Note that this also works for other kinds of "links" like:
 * `<input list="datalistID">`
 * `<td headers="header1ID,header2ID">`
 
-![GIF animation showing the Firefox DevTools Inspector panel, the mouse clicks the for attribute of a label element and the selection jumps to the related input element](/assets/img/jump-to-referenced-elements.gif)
+![Animation showing the Firefox DevTools Inspector panel, the mouse clicks the for attribute of a label element and the selection jumps to the related input element.](/assets/img/jump-to-referenced-elements.gif)
 
 Thank you to [Manuel Matuzović](https://twitter.com/mmatuzo) for [sharing on twitter](https://twitter.com/mmatuzo/status/1542768792836636672).

--- a/src/tips/en/live-expressions.md
+++ b/src/tips/en/live-expressions.md
@@ -20,6 +20,6 @@ You can use this, for example, to resize the window to a certain size by monitor
 `${window.outerWidth} x ${window.outerHeight}`
 ```
 
-![Monitoring the window size using live expressions](/assets/img/live-expressions-window-resize.gif)
+![Monitoring the window size using live expressions.](/assets/img/live-expressions-window-resize.gif)
 
 You can set as many live expressions as you want, and you can remove them by clicking the `x` icon next to them.

--- a/src/tips/en/manipulate-complex-json.md
+++ b/src/tips/en/manipulate-complex-json.md
@@ -17,4 +17,4 @@ https://www.youtube.com/watch?v=W8s9UiEhaLE
 
 Note that while the workflow works in every browser, the **Snippets** pane only exists in Edge and Chrome. In Firefox, you can use the [multi-line console](/tips/en/multi-line-console) to do the same thing.
 
-![Screenshot of VSCode with some JSON data and DevTools next to it with the snippets panel containing JS code to manipulate the JSON](/assets/img/manipulate-complex-json.png)
+![VSCode with some JSON data and DevTools next to it with the snippets panel containing JS code to manipulate the JSON.](/assets/img/manipulate-complex-json.png)

--- a/src/tips/en/monitor-element-events.md
+++ b/src/tips/en/monitor-element-events.md
@@ -16,6 +16,6 @@ You can replace `$0` with a reference to any other element. `$0` is just a short
 
 You can also change `key` to other event types like `mouse`.
 
-![GIF animation showing how events get automatically logged when using the monitorEvents function](/assets/img/monitor-element-events.gif)
+![Animation showing how events get automatically logged when using the monitorEvents function.](/assets/img/monitor-element-events.gif)
 
 Thank you to [Minko Gechev](https://github.com/mgechev) for [tweeting](https://twitter.com/mgechev/status/1447419251120279558) about this tip.

--- a/src/tips/en/move-panels.md
+++ b/src/tips/en/move-panels.md
@@ -15,7 +15,7 @@ There are 2 ways that you can re-arrange panels in DevTools today: dragging them
 
 This only works in Edge at the moment is makes it super easy to see any 2 tools at once (more information about [Edge personalization features](https://blogs.windows.com/msedgedev/2021/09/14/edge-devtools-93-personalization/)).
 
-![GIF animation in Edge DevTools showing the move to top/bottom menus](/assets/img/move-panels-1.gif)
+![Animation in Edge DevTools showing the move to top/bottom menus.](/assets/img/move-panels-1.gif)
 
 ### To re-order panels by dragging (Chrome, Edge, Firefox, Safari)
 
@@ -25,4 +25,4 @@ This only works in Edge at the moment is makes it super easy to see any 2 tools 
 
 If you use some tools more than others, this can be used to group them at the start of the toolbar for example.
 
-![GIF animation in Firefox DevTools showing how to move panels in the toolbar](/assets/img/move-panels-2.gif)
+![Animation in Firefox DevTools showing how to move panels in the toolbar.](/assets/img/move-panels-2.gif)

--- a/src/tips/en/multi-line-console.md
+++ b/src/tips/en/multi-line-console.md
@@ -11,8 +11,8 @@ Thankfully, there are a few ways to make your life easier by writing on multiple
 * Use <kbd>Shift</kbd>+<kbd>Enter</kbd> to create a new line without executing the expression. This works in all browsers.
 * Or use Firefox's multiline editor. To do this, click on the **Switch to multi-line editor mode** button located in the top-right corner of the **Console** message area (or press <kbd>Ctrl</kbd>+<kbd>B</kbd>).
 
-   ![Screenshot showing the button to switch the Firefox console to the multi-line mode](/assets/img/multi-line-console-firefox.png)
+   ![Tthe button to switch the Firefox console to the multi-line mode.](/assets/img/multi-line-console-firefox.png)
 
 * Or you can create code snippets in Edge, Chrome, or Safari's **Sources** tools. The added advantage of this technique is that code snippets are saved on your disk, and therefore can be used even after you've restarted the browser. See [Re-use scripts as snippets](/tips/en/use-scripts-as-snippets) for more information.
 
-   ![Screenshot showing the snippet tab in Edge's Sources panel](/assets/img/multi-line-console-snippet.png)
+   ![The snippet tab in Edge's Sources panel.](/assets/img/multi-line-console-snippet.png)

--- a/src/tips/en/node-screenshot.md
+++ b/src/tips/en/node-screenshot.md
@@ -10,7 +10,7 @@ In Firefox, Chrome, Polypane and Edge DevTools, you can screenshot a single node
 * Right-click on the node you want to screenshot.
 * Select **Capture node screenshot** (or **Screenshot node** in Firefox).
 
-![GIF animation showing taking a node screenshot in Firefox](/assets/img/node-screenshot.gif)
+![Animation showing taking a node screenshot in Firefox.](/assets/img/node-screenshot.gif)
 
 **In Polypane:**
 
@@ -18,4 +18,4 @@ In Firefox, Chrome, Polypane and Edge DevTools, you can screenshot a single node
 * Select "Element".
 * Click the element on your page you want to screenshot.
 
-![GIF animation showing taking a node screenshot in Polypane](/assets/img/node-screenshot-polypane.gif)
+![Animation showing taking a node screenshot in Polypane.](/assets/img/node-screenshot-polypane.gif)

--- a/src/tips/en/outline-everything.md
+++ b/src/tips/en/outline-everything.md
@@ -18,4 +18,4 @@ In Polypane:
 
 And voila! All elements are outlined and you can understand what's going on.
 
-![Gif animation showing how adding the rule in the styles pane if chrome devtools outlines all elements in the page](/assets/img/outline-everything.gif)
+![Animation showing how adding the rule in the styles pane if chrome devtools outlines all elements in the page.](/assets/img/outline-everything.gif)

--- a/src/tips/en/past-several-css-declarations.md
+++ b/src/tips/en/past-several-css-declarations.md
@@ -19,4 +19,4 @@ Now open DevTools, and the **Elements** (or **Inspector**) panel, find a CSS rul
 
 And now paste the code in. Instead of everything getting pasted in just this one text field, see how DevTools noticed that your clipboard contained multiple declarations, and created them all for you!
 
-![GIF animation showing how pasting several declarations in a CSS rule in DevTools creates them all](/assets/img/paste-several-css-declarations.gif)
+![Animation showing how pasting several declarations in a CSS rule in DevTools creates them all.](/assets/img/paste-several-css-declarations.gif)

--- a/src/tips/en/persist-logs-across-pages.md
+++ b/src/tips/en/persist-logs-across-pages.md
@@ -15,4 +15,4 @@ By default, the messages displayed in the console get removed as soon as you ref
 * In Polypane:
   * In the Console panel, check the "Preserve" box in the top toolbar
 
-![Screenshot of Edge devtools' console showing the settings panel at the top, with the "perserve log" box checked](/assets/img/persist-logs-across-pages.png)
+![Edge devtools' console showing the settings panel at the top, with the "perserve log" box checked.](/assets/img/persist-logs-across-pages.png)

--- a/src/tips/en/play-sound-on-js-execution.md
+++ b/src/tips/en/play-sound-on-js-execution.md
@@ -21,4 +21,4 @@ And that's it! Now every time this line is executed, an audio beep will be playe
 
 You can remove the breakpoint by right-clicking on it and selecting **Delete Breakpoint**.
 
-![GIF animation showing how to add the audio breakpoint in Safari Web Inspector](/assets/img/play-sound-on-js-execution.gif)
+![Animation showing how to add the audio breakpoint in Safari Web Inspector.](/assets/img/play-sound-on-js-execution.gif)

--- a/src/tips/en/prototype-content-changes-with-designmode.md
+++ b/src/tips/en/prototype-content-changes-with-designmode.md
@@ -21,4 +21,4 @@ In Polypane these steps are not neede and it's enough to open the **Debug tools*
 Changes are not persisted and will revert on page close or refresh.
 
 
-![Animated GIF of editable web page with designMode on](/assets/img/prototype-content-changes-with-designmode.gif)
+![Animation of editable web page with designMode on.](/assets/img/prototype-content-changes-with-designmode.gif)

--- a/src/tips/en/prototype-in-the-browser.md
+++ b/src/tips/en/prototype-in-the-browser.md
@@ -28,7 +28,7 @@ Turns out a quick way to do this is to start it directly in the browser, instead
    * To export the HTML code, I usually do this: right-click on the `<body>` element and choose **Copy inner HTML**.
    * To export the CSS code: in Firefox, I open the **Changes** sidebar panel and click **Copy All Changes** ([learn more](../find-css-changes)), and Chrome/Edge I go to **Sources**, find the **inspector-stylesheet** source and copy the content from it.
 
-![Screenshot of Edge , with a tab opened on the HTML data-url, and DevTools opened showing the Elements and Sources panels with local changes made](/assets/img/prototype-in-the-browser.png)
+![Edge , with a tab opened on the HTML data-url, and DevTools opened showing the Elements and Sources panels with local changes made.](/assets/img/prototype-in-the-browser.png)
 
 Here is a quick demo I did 4 years ago showing roughly this workflow. Things have changed a bit, but most of it still applies:
 

--- a/src/tips/en/query-dom-from-console.md
+++ b/src/tips/en/query-dom-from-console.md
@@ -10,4 +10,4 @@ They are essentially shortcuts to the longer `document.querySelector()` and `doc
 
 They're nice and short, and for those who worked with jQuery, they will feel familiar.
 
-![Firefox's console panel, showing 3 different examples of using the $ and $$ built-in console functions](/assets/img/query-dom-from-console.png)
+![Firefox's console panel, showing 3 different examples of using the $ and $$ built-in console functions.](/assets/img/query-dom-from-console.png)

--- a/src/tips/en/query-instances-holders.md
+++ b/src/tips/en/query-instances-holders.md
@@ -13,10 +13,10 @@ These two functions are really useful when your site starts using a lot of JavaS
 
 If `app.TodoItem` is a JavaScript class in your application, then `queryInstances(app.TodoItem)` will return an array of all of its instances.
 
-![Screenshot of the console in Safari, showing the result of queryInstances(app.TodoItem)](/assets/img/query-instances-holders-1.png)
+![The console in Safari, showing the result of queryInstances(app.TodoItem).](/assets/img/query-instances-holders-1.png)
 
 Or if you want to know what refers to the object you're debugging, use `queryHolders(this)`, which will return an array of all the other objects that have references to `this`.
 
-![Screenshot of the console in Safari, showing the result of queryHolders(this)](/assets/img/query-instances-holders-2.png)
+![The console in Safari, showing the result of queryHolders(this).](/assets/img/query-instances-holders-2.png)
 
 Learn more about these, and other, built-in functions [here](https://webkit.org/web-inspector/console-command-line-api/#functions).

--- a/src/tips/en/record-replay.md
+++ b/src/tips/en/record-replay.md
@@ -21,6 +21,6 @@ From that point on, the recording will be available in the **Recorder** panel an
 * Find your recording in the panel's initial screen, or from the dropdown located in the panel's toolbar.
 * Click the **Play recording** button.
 
-![GIF animation of the Recorder panel automatically replaying a set of recorded steps](/assets/img/record-replay.gif)
+![Animation of the Recorder panel automatically replaying a set of recorded steps.](/assets/img/record-replay.gif)
 
 You can learn a lot more about this panel (including how to edit a recording and how to use it to test performance improvements) in [the Recorder documentation](https://developer.chrome.com/docs/devtools/recorder/).

--- a/src/tips/en/reload-page-after-change.md
+++ b/src/tips/en/reload-page-after-change.md
@@ -16,6 +16,6 @@ Open the **Live Reload** panel:
 3. In the configuration screen (see screenshot below) select a directory and click **Start watching**.
 4. The reload button will show a lightning bolt when live reloading is active.
 
-![Polypane with the live reload panel and reload context menu visible](/assets/img/reload-page-after-change.png)
+![Polypane with the live reload panel and reload context menu visible.](/assets/img/reload-page-after-change.png)
 
 There are specific options to tweak, like which file system events to listen for, how long to wait before reloading (to account for things like SASS compilation time) and whether to show notifications of which files changed. [Learn more here](https://polypane.app/docs/live-auto-reloading/).

--- a/src/tips/en/remove-annoying-overlays.md
+++ b/src/tips/en/remove-annoying-overlays.md
@@ -13,6 +13,6 @@ To get rid of an annoying overlay, or any other element for that matter:
 1. On the webpage, select the element which you want to remove. As you hover elements, they will get highlighted. Use this highlight to make sure you're selecting the right element.
 1. Now, with the element selected in the **Inspector**/**Elements** panel, just press <kbd>Delete</kbd> on your keyboard to remove the element.
 
-![GIF animation showing the whole flow from selecting the element with the inspect tool and pressing delete, resulting in the element disappearing from the page](/assets/img/remove-annoying-overlays.gif)
+![Animation showing the whole flow from selecting the element with the inspect tool and pressing delete, resulting in the element disappearing from the page.](/assets/img/remove-annoying-overlays.gif)
 
 Credits go to [Chris Heilmann](https://christianheilmann.com/) for this tip and other cool DevTools tips for non-developers, which you can find here: [web cheatcodes](https://codepo8.github.io/web-cheatcodes/).

--- a/src/tips/en/sample-colors-from-the-page.md
+++ b/src/tips/en/sample-colors-from-the-page.md
@@ -11,13 +11,13 @@ Being able to sample colors from the page is super useful. Firefox, Edge and Chr
   * Go to the "More Tools" submenu
   * Click on the Eyedropper menu item
 
-![Gif animation of the eyedropper tool being started from the firefox main menu](/assets/img/sample-colors-from-the-page-1.gif)
+![Animation of the eyedropper tool being started from the Firefox main menu.](/assets/img/sample-colors-from-the-page-1.gif)
 
 * There is a second way to do this in Firefox from DevTools:
   * Open the Inspector panel
   * Click on the eye dropper button in the typ-right corner of the panel
 
-![Screenshot of the eyedropper button in Firefox's inspector panel](/assets/img/sample-colors-from-the-page-2.png)
+![The eyedropper button in Firefox's inspector panel.](/assets/img/sample-colors-from-the-page-2.png)
 
 * In Polypane you also do not need devtools
   * Click the eye dropper icon in the address bar.
@@ -25,7 +25,7 @@ Being able to sample colors from the page is super useful. Firefox, Edge and Chr
 
   After selecting a color, an overview of previously selected colors, previews and contrast ratios is shown.
 
-![GIF animation of starting the eyedropper tool from Polypane's address bar](/assets/img/sample-colors-from-the-page-4.gif)
+![Animation of starting the eyedropper tool from Polypane's address bar.](/assets/img/sample-colors-from-the-page-4.gif)
 
 
 
@@ -35,4 +35,4 @@ Being able to sample colors from the page is super useful. Firefox, Edge and Chr
   * Find the color in the Styles pane and click on the color swatch icon next to it
   * Just start moving the mouse over the page
 
-![Gif animation of starting the eyedropper tool from chrome and edge's color pickers](/assets/img/sample-colors-from-the-page-3.gif)
+![Animation of starting the eyedropper tool from chrome and edge's color pickers.](/assets/img/sample-colors-from-the-page-3.gif)

--- a/src/tips/en/scroll-into-view.md
+++ b/src/tips/en/scroll-into-view.md
@@ -11,4 +11,4 @@ DevTools has got your back here! You can easily reveal where the selected elemen
 * Right-click the element in the **Elements** panel (or **Inspector** panel in Firefox).
 * Click **Scroll into view** (in Firefox, you can also press <kbd>S</kbd>).
 
-![GIF animation showing how the page is scrolled to reveal the selected element](/assets/img/scroll-into-view.gif)
+![Animation showing how the page is scrolled to reveal the selected element.](/assets/img/scroll-into-view.gif)

--- a/src/tips/en/see-json-responses.md
+++ b/src/tips/en/see-json-responses.md
@@ -10,7 +10,7 @@ You don't even need to open DevTools for it to work! Just enter the URL to a JSO
 
 You can try it out with [this sample JSON response](https://jsonplaceholder.typicode.com/posts/1/comments), or [these JSON test files](https://codepo8.github.io/json-dummy-data/).
 
-![The JSON viewer in Microsoft Edge](/assets/img/see-json-responses.png)
+![The JSON viewer in Microsoft Edge.](/assets/img/see-json-responses.png)
 
 Note that in Firefox and Polypane, the JSON viewer has a few more options not yet available in Edge:
 

--- a/src/tips/en/see-quick-a11y-info-on-hover.md
+++ b/src/tips/en/see-quick-a11y-info-on-hover.md
@@ -9,4 +9,4 @@ In Edge, Polypane and Chrome, whenever you use the element selector and hover ov
 * To start the element selector, click on the mouse cursor icon in the top-left corner of the DevTools window.
 * Then simply hover over elements in the page
 
-![gif animation of the a11y tooltip in chrome](/assets/img/see-quick-a11y-info-on-hover.gif)
+![Animation of the a11y tooltip in chrome.](/assets/img/see-quick-a11y-info-on-hover.gif)

--- a/src/tips/en/see-the-page-in-3d.md
+++ b/src/tips/en/see-the-page-in-3d.md
@@ -12,8 +12,8 @@ See your page in 3 dimensions to quickly find out how deeply nested it is, fix z
   * In the new panel that opens, switch between the 3 modes: z-index, DOM, and Composited Layers to visualize the page in 3D.
 * Chrome and Safari also have a Layers panel that provides the same information as Edge's Composited Layers 3D mode.
 
-![Screenshot of the 3D view tool showing a page's z-index stacking tree as a 3d scene](/assets/img/see-the-page-in-3d.png)
+![The 3D view tool showing a page's z-index stacking tree as a 3d scene.](/assets/img/see-the-page-in-3d.png)
 
-More information on Edge's 3D tool in this video: 
+More information on Edge's 3D tool in this video:
 
 https://www.youtube.com/watch?v=BZAH8ZXhHZA

--- a/src/tips/en/select-pointer-events-none-elements.md
+++ b/src/tips/en/select-pointer-events-none-elements.md
@@ -10,7 +10,7 @@ Indeed, if an element does not react to pointer events because the `pointer-even
 
 In Chrome, Edge, Polypane and Firefox, you can hold the <kbd>Shift</kbd> key on your keyboard while hovering elements in the page! When you do this, even elements with `pointer-events:none` can be selected!
 
-![Gif animation showing how a pointer-events:none element normally can't be selected, except when Shift is pressed](/assets/img/select-pointer-events-none-elements.gif)
+![Animation showing how a pointer-events:none element normally can't be selected, except when Shift is pressed.](/assets/img/select-pointer-events-none-elements.gif)
 
 [Šime Vidas](https://twitter.com/simevidas/status/1464501900586463236) also proposed this alternative solution in Firefox:
 

--- a/src/tips/en/simulate-color-vision-deficiencies.md
+++ b/src/tips/en/simulate-color-vision-deficiencies.md
@@ -12,17 +12,17 @@ Firefox, Chrome, Polypane and Edge make it possible for you to test how a web pa
   * Go to the Accessibility panel
   * In the toolbar at the top, choose from a selection of different color vision deficiencies in the "Simulate" drop-down
 
-![Screenshot of the color vision simulation drop-down in Firefox](/assets/img/simulate-color-vision-deficiencies-1.png)
+![The color vision simulation drop-down in Firefox.](/assets/img/simulate-color-vision-deficiencies-1.png)
 
 * In Chrome, or in Edge:
   * You first need to open the Rendering panel. Either use the [command menu](/tips/en/execute-commands/) and type `rendering` or use the main menu (the three-dots icon in the top-right corner of the screen) and go to More Tools to find it.
   * Scroll down until you find the "Emulate vision deficiencies" section, and choose from the drop-down
 
-![Screenshot of the color vision simulation drop-down in Chrome](/assets/img/simulate-color-vision-deficiencies-2.png)
+![The color vision simulation drop-down in Chrome.](/assets/img/simulate-color-vision-deficiencies-2.png)
 
 * In Polypane:
   * Open the **Debug tools** option of a pane.
   * Switch to **Simulators**.
   * Select one of the nine available color vision simulators or hover over the "i" icon for additional information.
 
-![Screenshot of the simulator drop-down in Polypane](/assets/img/simulate-color-vision-deficiencies-3.png)
+![The simulator drop-down in Polypane.](/assets/img/simulate-color-vision-deficiencies-3.png)

--- a/src/tips/en/simulate-devices.md
+++ b/src/tips/en/simulate-devices.md
@@ -6,7 +6,7 @@ tags: ["testing", "browser:edge", "browser:firefox", "browser:chrome", "browser:
 ---
 There is a great mode in all major browser developer tools that makes it really easy to test your webpage under different screen sizes and even simulate other devices.
 
-![Animation showing how the tool makes it easy to resize the screen size by dragging the mouse](/assets/img/simulate-devices.gif)
+![Animation showing how the tool makes it easy to resize the screen size by dragging the mouse.](/assets/img/simulate-devices.gif)
 
 To enable it:
 

--- a/src/tips/en/simulate-geolocation.md
+++ b/src/tips/en/simulate-geolocation.md
@@ -16,4 +16,4 @@ Chrome and Edge DevTools have a built-in way to simulate any location:
 
 In the following screenshot, the webpage is google.com and the location was set to São Paulo, Brazil. After a refresh, the google.com homepage shows the text in Portuguese.
 
-![Chrome, showing Google in Portuguese, with DevTools opened to the side and the Sensors tool showing that the geolocation was set to São Paulo](/assets/img/simulate-geolocation.png)
+![Chrome, showing Google in Portuguese, with DevTools opened to the side and the Sensors tool showing that the geolocation was set to São Paulo.](/assets/img/simulate-geolocation.png)

--- a/src/tips/en/simulate-pseudo-classes.md
+++ b/src/tips/en/simulate-pseudo-classes.md
@@ -8,9 +8,9 @@ If you use `:hover`, `:active`, and other such pseudo-classes in CSS, you can ac
 
 Open the Styles panel (in Chrome, Edge or Safari) or the Rules panel (in Firefox), and click the `:hov` button. This will expand a section that allows you to lock one or multiple of these pseudo-classes on the selected element.
 
-![Screenshot of the :hov panel to simulate various pseudo-classes](/assets/img/simulate-pseudo-classes.png)
+![The :hov panel to simulate various pseudo-classes.](/assets/img/simulate-pseudo-classes.png)
 
-This is great when you write your styles, as you can define see the changes to - for example - a hover state of an element without having to use your mouse to see it in action. 
+This is great when you write your styles, as you can define see the changes to - for example - a hover state of an element without having to use your mouse to see it in action.
 
 It is even more useful when you want to test the different states of an element. In the following screencast you can see how to use the state simulation to check the hover, active, visited and focused state of a link without having to interact with the link using your keyboard or mouse. If you want to try it out yourself, [here is the demo page](https://codepen.io/codepo8/pen/WNEMaPO).
 

--- a/src/tips/en/spot-out-of-viewport-elements.md
+++ b/src/tips/en/spot-out-of-viewport-elements.md
@@ -14,4 +14,4 @@ Here's a nice tip to quickly find out-of-viewport elements, by using the **3D Vi
 * In the left sidebar, choose the **DOM** tab.
 * Zoom and pan the 3D scene to find out of viewport elements!
 
-![A screenshot of Edge DevTools showing the Elements tool at the top with the DOM tree and the 3D View tool at the bottom, showing a 3D render of the page, with most elements in the same rectangle, and 2 smaller elements outside of the main rectangle](/assets/img/spot-out-of-viewport-elements.png)
+![Edge DevTools showing the Elements tool at the top with the DOM tree and the 3D View tool at the bottom, showing a 3D render of the page, with most elements in the same rectangle, and 2 smaller elements outside of the main rectangle.](/assets/img/spot-out-of-viewport-elements.png)

--- a/src/tips/en/store-node-as-variable.md
+++ b/src/tips/en/store-node-as-variable.md
@@ -13,6 +13,6 @@ The **Console** opens up, pre-filled with a new variable name (something like `t
 
 Note that if you only want to refer to the currently selected node (and not create a new variable), you can also [use `$0` in the console](/tips/en/get-current-element-in-console).
 
-![screenshot of firefox's "use in console" context menu option in the Inspector, and also showing the Console with a couple of tempN variables](/assets/img/store-node-as-variable.png)
+![Firefox's "use in console" context menu option in the Inspector, and also showing the Console with a couple of tempN variables.](/assets/img/store-node-as-variable.png)
 
 Thank you [Austin Gil](https://austingil.com/) for sharing this tip on [Twitter](https://twitter.com/Stegosource/status/1451294683024355328)!

--- a/src/tips/en/style-console-messages.md
+++ b/src/tips/en/style-console-messages.md
@@ -10,4 +10,4 @@ The `console.log` output can be styled in DevTools using CSS.
 console.log('%c Hello World', 'color: orange; font-size: 2em;');
 ```
 
-![Screenshot of a styled console message in Edge](/assets/img/style-console-messages.png)
+![A styled console message in Edge.](/assets/img/style-console-messages.png)

--- a/src/tips/en/suppressed-event-listeners-when-paused.md
+++ b/src/tips/en/suppressed-event-listeners-when-paused.md
@@ -15,4 +15,4 @@ This also happens if you manually try to dispatch new events from the console us
 
 The reason for this is that (ignoring workers) JavaScript on your page only runs in one thread. So while that thread is paused at one specific location, it's not supposed to be able to execute code from other locations.
 
-![Screenshot of a page in edge with the DevTools Sources paused at a location, and the on-page overlay preventing access to the page](/assets/img/suppressed-event-listeners-when-paused.png)
+![A page in edge with the DevTools Sources paused at a location, and the on-page overlay preventing access to the page.](/assets/img/suppressed-event-listeners-when-paused.png)

--- a/src/tips/en/take-in-device-screenshots.md
+++ b/src/tips/en/take-in-device-screenshots.md
@@ -12,11 +12,11 @@ To take a screenshot of a web page inside a device frame, use either Chrome or E
 
 * In DevTools, turn on **Device Emulation** by clicking the icon or pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd> (<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd> on Mac).
 * Select a device from the Device dropdown menu. Be aware that not all devices have graphical frames.
-   ![The device dropdown menu open and showing all the options](/assets/img/take-in-device-screenshots-devices-dropdown.png)
+   ![The device dropdown menu open and showing all the options.](/assets/img/take-in-device-screenshots-devices-dropdown.png)
 * Click the **…** button (**More options**) and select **Show device frame**.
-   ![Turning on device frame in the more options menu of the Device emulation tool](/assets/img/take-in-device-screenshots-show-device-frame.png)
+   ![Turning on device frame in the more options menu of the Device emulation tool.](/assets/img/take-in-device-screenshots-show-device-frame.png)
 * Click the **…** button again and select **Capture screenshot**.
-   ![Selecting the screenshot option from the More Options menu](/assets/img/take-in-device-screenshots-capture-screenshot.png)
+   ![Selecting the screenshot option from the More Options menu.](/assets/img/take-in-device-screenshots-capture-screenshot.png)
 
 That's it, you now have a photo of your web page inside a device on transparent background.
 

--- a/src/tips/en/test-pwa-protocol-handlers.md
+++ b/src/tips/en/test-pwa-protocol-handlers.md
@@ -25,4 +25,4 @@ To test your handler:
 
    Your installed PWA should now be launched automatically, and you can test your protocol handling code.
 
-![Microsoft Edge, with the Application tool opened on the side, showing the Protocol Handlers section](/assets/img/test-pwa-protocol-handlers.png)
+![Microsoft Edge, with the Application tool opened on the side, showing the Protocol Handlers section.](/assets/img/test-pwa-protocol-handlers.png)

--- a/src/tips/en/throttle-network-speed.md
+++ b/src/tips/en/throttle-network-speed.md
@@ -17,7 +17,7 @@ To throttle your connection:
 
 You can also do this from the [device simulation](/tips/en/simulate-devices) mode by using the same dropdown there.
 
-![Screenshot of the Network panel in Edge showing the network throttling drop-down](/assets/img/throttle-network-speed.png)
+![The Network panel in Edge showing the network throttling drop-down.](/assets/img/throttle-network-speed.png)
 
 In Polypane:
 
@@ -25,4 +25,4 @@ In Polypane:
 * Go to the **Network** tab.
 * Toggle between the different network speed settings
 
-![Screenshot of the Network option in Polypane](/assets/img/throttle-network-speed-2.png)
+![The Network option in Polypane.](/assets/img/throttle-network-speed-2.png)

--- a/src/tips/en/track-focused-element.md
+++ b/src/tips/en/track-focused-element.md
@@ -11,4 +11,4 @@ If you want to know which element has the focus on the web page at any time, you
 1. In the text box that appears, type `document.activeElement`.
 1. Now click/tab around on the page and see the live expression update to reflect which element is currently focused.
 
-![GIF animation showing a web page with focus going through different element, and the Edge Console panel with the live expression showing a preview of the focused element](/assets/img/track-focused-element.gif)
+![Animation showing a web page with focus going through different element, and the Edge Console panel with the live expression showing a preview of the focused element.](/assets/img/track-focused-element.gif)

--- a/src/tips/en/tweak-grid-flex-alignment.md
+++ b/src/tips/en/tweak-grid-flex-alignment.md
@@ -11,4 +11,4 @@ Chrome and Edge both have a visual editor useful for tweaking flexbox and grid a
 * In the Styles sidebar pane, find the `display: grid` or `display:flex` declaration
 * Click the little icon next to this declaration
 
-![Screenshot of the grid editor in the Styles pane of Microsoft Edge](/assets/img/tweak-grid-flex-alignment.png)
+![The grid editor in the Styles pane of Microsoft Edge.](/assets/img/tweak-grid-flex-alignment.png)

--- a/src/tips/en/understand-flexbox-item-sizing.md
+++ b/src/tips/en/understand-flexbox-item-sizing.md
@@ -28,4 +28,4 @@ Here is the information that might be displayed:
 * **Max or min size**: whether the item has a max or min size defined (e.g. using `min-width` or `max-width` in row direction). This can _clamp_ the item, even if it wanted to grow or shrink more.
 * **Final size**: the actual final size of the item.
 
-![Firefox, with the DevTools Inspector tool opened, showing the Layout sidebar that contains the flex item diagram](/assets/img/understand-flexbox-item-sizing.png)
+![Firefox, with the DevTools Inspector tool opened, showing the Layout sidebar that contains the flex item diagram.](/assets/img/understand-flexbox-item-sizing.png)

--- a/src/tips/en/unminify-javascript-code.md
+++ b/src/tips/en/unminify-javascript-code.md
@@ -11,4 +11,4 @@ You can unminify code in DevTools to read it more easily, and also set breakpoin
 * Open a file in the Sources or Debugger panel
 * Click on the `{}` icon at the bottom of the source code
 
-![Screenshot of the Sources panel in Chrome, showing the pretty-print button](/assets/img/unminify-javascript-code.gif)
+![The Sources panel in Chrome, showing the pretty-print button.](/assets/img/unminify-javascript-code.gif)

--- a/src/tips/en/use-another-language.md
+++ b/src/tips/en/use-another-language.md
@@ -25,4 +25,4 @@ For Safari, you can set the app level language in MacOS by using **System prefer
 
 Add the Safari app and choose the language. Restart Safari.  and then the browser & the DevTools will use the selected language.
 
-![Screenshot of the settings panel in Edge showing a checkbox to match devtools with the browser language](/assets/img/use-another-language.png)
+![The settings panel in Edge showing a checkbox to match devtools with the browser language.](/assets/img/use-another-language.png)

--- a/src/tips/en/use-full-browser-for-device-emulation.md
+++ b/src/tips/en/use-full-browser-for-device-emulation.md
@@ -12,4 +12,4 @@ Firefox has a keyboard shortcut to show device emulation without Developer Tools
 
 On Chromium based browsers like Chrome and Edge the trick is to start the device emulation and then un-dock the Developer Tools. You can un-dock the tools into their own window using the `…` menu. This gives you the full browser as an emulation playground.
 
-![Screencast showing device emulation andhow to undock the Developer Tools into an own window](/assets/img/use-full-browser-for-device-emulation.gif)
+![Animation showing device emulation and how to undock the Developer Tools into an own window.](/assets/img/use-full-browser-for-device-emulation.gif)

--- a/src/tips/en/use-logpoints.md
+++ b/src/tips/en/use-logpoints.md
@@ -6,11 +6,11 @@ tags: ["debug", "javascript", "browser:edge", "browser:chrome", "browser:firefox
 ---
 Using the [console](https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/console/) to log some information is a very common way to debug your JavaScript. But you can also log information in any web site using **Logpoints** in the [sources](https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/sources/) panel.
 
-![Screenshots of the way to set a logpoint in the sources tool](/assets/img/use-logpoints.png)
+![Setting a logpoint in the sources tool.](/assets/img/use-logpoints.png)
 
 Here's how to do it:
 
-1. In the Sources panel (or Debugger in Firefox), open a JavaScript file and right-click any line number. 
+1. In the Sources panel (or Debugger in Firefox), open a JavaScript file and right-click any line number.
 1. Select `Add logpoint` to open the editor
 1. In the editor, enter the JavaScript expression you'd like to log.
 1. Hit Enter to save and a badge shows on the line number.

--- a/src/tips/en/use-scripts-as-snippets.md
+++ b/src/tips/en/use-scripts-as-snippets.md
@@ -18,25 +18,25 @@ You can create as many named snippets as you like and remove ones you don't need
 
 Snippets have full access to the window object and you can use any of the console API methods in them too. For example, this script would replace each image in the document with its alternative text:
 
-```javascript 
+```javascript
 $$('img').forEach(i=>{
    let txt = document.createElement('span');
    txt.innerText = i.alt;
    i.parentNode.replaceChild(txt,i);
-   console.log(i.alt); 
+   console.log(i.alt);
 });
 ```
 
 You can run snippets by pressing <kbd>ctrl</kbd>+<kbd>Enter</kbd> (or <kbd>cmd</kbd>+<kbd>Enter</kbd> on mac) or using the button on the bottom of the editor.
 
-![The snippets editor in the Sources tool with a snippet open in the editor](/assets/img/use-scripts-as-snippets-1.png)
+![The snippets editor in the Sources tool with a snippet open in the editor.](/assets/img/use-scripts-as-snippets-1.png)
 
 Even better, you can use the [Command menu](/tips/en/execute-commands) to run snippets more easily. Simply press <kbd>ctrl</kbd>+<kbd>P</kbd> (or <kbd>cmd</kbd>+<kbd>P</kbd> on mac) and type `!` followed by the name of your Snippet.
 
-![Running a snippet from the Command menu](/assets/img/use-scripts-as-snippets-2.gif)
+![Running a snippet from the Command menu.](/assets/img/use-scripts-as-snippets-2.gif)
 
 ### In Safari
 
 In Safari, these scripts are called Console Snippets and can also be created from the **Sources** tool by clicking the `+` icon at the bottom of the tool, and choosing **Console Snippet...**.
 
-![Creating a snippet in Safari](/assets/img/use-scripts-as-snippets-3.gif)
+![Creating a snippet in Safari.](/assets/img/use-scripts-as-snippets-3.gif)

--- a/src/tips/en/view-perf-markers-in-order.md
+++ b/src/tips/en/view-perf-markers-in-order.md
@@ -8,4 +8,4 @@ When logging `performance.timing` events to the console, they appear in alphabet
 
 In order to view them in order, you can use `console.table(performance.timing)` and click on the column heading to sort them by time.
 
-![Screenshot of the console in Edge showing the PerformanceTiming object, with alphabetical properties, and then using console.table to sort properties](/assets/img/view-perf-markers-in-order.png)
+![The console in Edge showing the PerformanceTiming object, with alphabetical properties, and then using console.table to sort properties.](/assets/img/view-perf-markers-in-order.png)

--- a/src/tips/en/visualize-css-transforms.md
+++ b/src/tips/en/visualize-css-transforms.md
@@ -15,6 +15,6 @@ Being able to compare the 2 states at the same time makes it easier to debug you
 * Hover over the property value.
 * The on-page highlighter appears.
 
-![GIF animation showing how the CSS transform highlighter appears on the page when hovering over a transform CSS property in the Rules panel](/assets/img/visualize-css-transforms.gif)
+![Animation showing how the CSS transform highlighter appears on the page when hovering over a transform CSS property in the Rules panel.](/assets/img/visualize-css-transforms.gif)
 
 [Learn more about it here](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Visualize_transforms).

--- a/src/tips/en/visualize-screenreader-order.md
+++ b/src/tips/en/visualize-screenreader-order.md
@@ -14,6 +14,6 @@ This tool adds a layer on the page that shows the order in which elements would 
 * Go to the Accessibility panel
 * In the toolbar, check the "Show source order" box
 
-![Screenshot of the source order viewer in Microsoft Edge, showing numbered boxes around elements](/assets/img/visualize-screenreader-order.png)
+![The source order viewer in Microsoft Edge, showing numbered boxes around elements.](/assets/img/visualize-screenreader-order.png)
 
 [Learn more about it here](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/accessibility/test-tab-key-source-order-viewer#analyzing-the-order-of-keyboard-access-through-sections-of-the-page).

--- a/src/tips/en/visualize-tabbing-order.md
+++ b/src/tips/en/visualize-tabbing-order.md
@@ -17,7 +17,7 @@ This tool adds a layer on the page that shows the order in which elements would 
 * Go to the Accessibility panel
 * In the toolbar, check the "Show Tabbing Order" box
 
-![Screenshot of the tabbing order highlighter in Firefox, showing numbered boxes around focusable elements](/assets/img/visualize-tabbing-order.png)
+![The tabbing order highlighter in Firefox, showing numbered boxes around focusable elements.](/assets/img/visualize-tabbing-order.png)
 
 [Learn more about it here](https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector#show_web_page_tabbing_order).
 
@@ -29,6 +29,6 @@ This tool shows the tabbing order in a list that also warns you about issues wit
 
 Click **Show overlay** to add a layer to the page that draws a line from each element to the next, to make it easy to follow.
 
-![Screenshot of the tabbing order highlighter in Polypane, showing numbered boxes and a line going from each focusable element to the next](/assets/img/visualize-tabbing-order-polypane.png)
+![The tabbing order highlighter in Polypane, showing numbered boxes and a line going from each focusable element to the next.](/assets/img/visualize-tabbing-order-polypane.png)
 
 [Learn more about it here](https://polypane.app/docs/outline-panel/#focus-order-tab-order).

--- a/src/tips/en/zoom-devtools-content.md
+++ b/src/tips/en/zoom-devtools-content.md
@@ -11,4 +11,4 @@ To zoom the UI of DevTools:
 * Make sure it has focus first (click somewhere in DevTools).
 * Use the <kbd>Ctrl</kbd>+<kbd>+</kbd> and <kbd>Ctrl</kbd>+<kbd>-</kbd> keyboard shortcuts to zoom in or out (replace <kbd>Ctrl</kbd> with <kbd>Cmd</kbd> on Mac).
 
-![Gif demo showing the UI of Chrome DevTools being zoomed in and out](/assets/img/zoom-devtools-content.gif)
+![Animation showing the UI of Chrome DevTools being zoomed in and out.](/assets/img/zoom-devtools-content.gif)


### PR DESCRIPTION
- remove all "Screenshot of"
- add period at the end of sentences for correct pronunciation by screen readers
- normalise gif/GIF/animation/screencast to "Animation"
- small typos here and there

fixes #47