### PR TITLE
Added link for "Edit Page"

### DIFF
--- a/src/layouts/tip.njk
+++ b/src/layouts/tip.njk
@@ -24,7 +24,7 @@ templateEngineOverride: njk
 <div class="tip-footer">
     {%- if not isTweet -%}
         <div class="authors">Authors: <span>{% formatAuthors authors %}</span></div>
-        <p class="last-edit">Last edit: <time datetime="{{ page.date.toISOString() }}">{{ page.date.toLocaleDateString() }}</time></p>
+        <p class="last-edit">Last edit: <time datetime="{{ page.date.toISOString() }}">{{ page.date.toLocaleDateString() }}</time> - <a href="https://github.com/captainbrosset/devtools-tips/edit/main/{{ page.inputPath }}">Edit page</a></p>
     {%- endif -%}
 </div>
 <script async src="/assets/share.js"></script>


### PR DESCRIPTION
I find the Edit link useful which takes me directly to the page that needs to be edited on Github, since I do most of my dev work inside the browser. Otherwise, I need to search through the tips directory to locate the correct file.

<img width="840" alt="image" src="https://user-images.githubusercontent.com/38640616/211004722-573148b8-03e9-4200-84e2-4e3db4771678.png">
