### PR TITLE
WIP Feature/views transition api

### DIFF
--- a/src/assets/dialog-lightbox.js
+++ b/src/assets/dialog-lightbox.js
@@ -34,9 +34,13 @@ function createDialogs(selector) {
     button.after(dialog);
 
     const showDialog = () => {
-      img.style.viewTransitionName = "";
-      dialog.style.setProperty("width", img.naturalWidth + "px");
-      dialog.showModal();
+      if (dialog.open) {
+        dialog.close();
+      } else {
+        img.style.viewTransitionName = "";
+        dialog.style.setProperty("width", img.naturalWidth + "px");
+        dialog.showModal();
+      }
     };
 
     button.addEventListener("click", () => {
@@ -48,10 +52,15 @@ function createDialogs(selector) {
       document.startViewTransition(() => showDialog());
     });
 
-    dialog.addEventListener(
-      "click",
-      event => event.target === dialog && dialog.close()
-    );
+    dialog.addEventListener("click", (event) => {
+      if (event.target === dialog) {
+        if (!document.startViewTransition) {
+          showDialog();
+          return;
+        }
+        document.startViewTransition(() => showDialog());
+      }
+    });
   }
 
   [...document.querySelectorAll(selector)].forEach(createDialog);

--- a/src/assets/dialog-lightbox.js
+++ b/src/assets/dialog-lightbox.js
@@ -33,9 +33,19 @@ function createDialogs(selector) {
     button.append(img);
     button.after(dialog);
 
-    button.addEventListener("click", () => {
+    const showDialog = () => {
+      img.style.viewTransitionName = "";
       dialog.style.setProperty("width", img.naturalWidth + "px");
       dialog.showModal();
+    };
+
+    button.addEventListener("click", () => {
+      if (!document.startViewTransition) {
+        showDialog();
+        return;
+      }
+      img.style.viewTransitionName = "image";
+      document.startViewTransition(() => showDialog());
     });
 
     dialog.addEventListener(

--- a/src/assets/dialog-lightbox.js
+++ b/src/assets/dialog-lightbox.js
@@ -27,39 +27,51 @@ function createDialogs(selector) {
     const form = dialog.querySelector("form");
     const span = dialog.querySelector("form > span");
 
-    span.before(img.cloneNode());
     span.textContent = img.getAttribute("alt");
     img.before(button);
     button.append(img);
     button.after(dialog);
 
-    const showDialog = () => {
+
+    img.style.viewTransitionName = "image";
+
+    const toggleDialog = () => {
       if (dialog.open) {
+        button.append(img);
         dialog.close();
       } else {
-        img.style.viewTransitionName = "";
-        dialog.style.setProperty("width", img.naturalWidth + "px");
+        span.before(img);
+        span.style.setProperty("max-width", img.naturalWidth + "px");
         dialog.showModal();
       }
     };
 
-    button.addEventListener("click", () => {
+    button.addEventListener("click", (e) => {
       if (!document.startViewTransition) {
-        showDialog();
+        toggleDialog();
         return;
       }
-      img.style.viewTransitionName = "image";
-      document.startViewTransition(() => showDialog());
+
+      document.startViewTransition(() => toggleDialog());
     });
 
     dialog.addEventListener("click", (event) => {
       if (event.target === dialog) {
         if (!document.startViewTransition) {
-          showDialog();
+          toggleDialog();
           return;
         }
-        document.startViewTransition(() => showDialog());
+        document.startViewTransition(() => toggleDialog());
       }
+    });
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      if (!document.startViewTransition) {
+        toggleDialog();
+        return;
+      }
+      document.startViewTransition(() => toggleDialog());
     });
   }
 

--- a/src/assets/dialog-lightbox.js
+++ b/src/assets/dialog-lightbox.js
@@ -8,10 +8,9 @@ function createDialogs(selector) {
   const buttonTemplate = document.createElement("button");
   buttonTemplate.classList.add("lightbox-button");
   buttonTemplate.setAttribute("aria-haspopup", "dialog");
+
   const dialogTemplate = document.createElement("dialog");
-
   dialogTemplate.classList.add("lightbox");
-
   dialogTemplate.innerHTML = `
     <form method="dialog">
       <button type="submit">
@@ -67,18 +66,15 @@ function createDialogs(selector) {
     [
       { el: button, ev: "click" },
       { el: dialog, ev: "cancel" },
+      { el: dialog, ev: "click", condition: (e) => e.target === dialog },
       { el: form, ev: "submit" },
-    ].forEach((handler) => {
-      handler.el.addEventListener(handler.ev, (e) => {
-        e.preventDefault();
-        callToggleDialog();
+    ].forEach(({ el, ev, condition = () => true }) => {
+      el.addEventListener(ev, (e) => {
+        if (condition(e)) {
+          e.preventDefault();
+          callToggleDialog();
+        }
       });
-    });
-
-    dialog.addEventListener("click", (e) => {
-      if (e.target === dialog) {
-        callToggleDialog();
-      }
     });
   }
 

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -656,16 +656,12 @@ footer a {
   border: none;
   background: none;
   padding: 0;
-  max-width: 98vw;
-  max-height: 98vh;
+  max-width: calc(100vw - 1rem);
+  max-height: calc(100vh - 1rem);
   color: inherit;
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .lightbox[open] {
-    animation: show 0.25s ease-in-out normal;
-  }
-
   @keyframes show {
     from {
       opacity: 0;

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -647,8 +647,11 @@ footer a {
     center/80%;
   z-index: 1;
   transition: 0.25s ease-in-out background;
-  view-transition-name: zoombutton;
   contain: layout;
+}
+
+.lightbox--transition.lightbox-button::after {
+  view-transition-name: zoombutton;
 }
 
 .lightbox-button:hover::after {
@@ -688,32 +691,35 @@ footer a {
     z-index: 10;
   }
   ::view-transition-group(image) {
-    animation-duration: 0.5s;
+    animation-duration: 0.25s;
     z-index: 30;
   }
 
   ::view-transition-group(button) {
-    animation-delay: 0.5s;
+    animation-delay: 0.25s;
     animation-duration: 0.25s;
     z-index: 40;
   }
 
   ::view-transition-group(zoombutton) {
-    animation-delay: 0.5s;
+    animation-delay: 0.25s;
     animation-duration: 0.25s;
     z-index: 40;
     animation-name: show;
 
   ::view-transition-group(dialog) {
-    animation-delay: 0.5s;
+    animation-delay: 0.25s;
     z-index: 20;
   }
 }
 
 .lightbox::backdrop {
   background: var(--lightbox-backdrop);
-  view-transition-name: backdrop;
   contain: layout;
+}
+
+.lightbox--transition.lightbox::backdrop {
+  view-transition-name: backdrop;
 }
 
 .lightbox form {
@@ -722,8 +728,10 @@ footer a {
   border-radius: 5px;
   padding: 1rem 1rem 0;
   grid-template-rows: 0 1fr min-content;
-  view-transition-name: dialog;
   contain: layout;
+}
+.lightbox--transition.lightbox form {
+  view-transition-name: dialog;
 }
 
 .lightbox img {
@@ -763,8 +771,10 @@ footer a {
   color: var(--accent-color-darker);
   transition: 0.25s ease-in-out background;
   z-index: 1;
-  view-transition-name: button;
   contain: layout;
+}
+.lightbox--transition.lightbox button {
+  view-transition-name: button;
 }
 .lightbox button:hover {
   background-color: var(--accent-color);

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -677,26 +677,28 @@ footer a {
 
   @supports selector(::view-transition) {
     .lightbox {
-      animation-duration:0s;
+      animation-duration: 0s;
     }
   }
 
   ::view-transition-group(backdrop) {
-    animation-name: show;
     animation-duration: 0.25s;
     z-index: 1;
   }
   ::view-transition-group(image) {
-    animation-duration: 0.55s;
-    animation-iteration-count: 1;
+    animation-duration: 0.5s;
     z-index: 3;
   }
 
   ::view-transition-group(button) {
-    animation-delay: 0.55s;
-    animation-name: show;
+    animation-delay: 0.5s;
     animation-duration: 0.25s;
     z-index: 4;
+  }
+
+  ::view-transition-group(dialog) {
+    animation-duration: 0.5s;
+    z-index: 2;
   }
 }
 
@@ -716,6 +718,8 @@ footer a {
   border-radius: 5px;
   padding: 1rem 1rem 0;
   grid-template-rows: 0 1fr min-content;
+  view-transition-name: dialog;
+  contain: layout;
 }
 
 .lightbox img {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -663,12 +663,21 @@ footer a {
 }
 
 @media (prefers-reduced-motion: no-preference) {
+  .lightbox {
+    animation: show 0.25s ease-in-out normal;
+  }
   @keyframes show {
     from {
       opacity: 0;
     }
     to {
       opacity: 1;
+    }
+  }
+
+  @supports selector(::view-transition) {
+    .lightbox {
+      animation-duration:0s;
     }
   }
 

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -388,7 +388,7 @@ main h2.tip-title {
     grid-column: 1;
     grid-row: 4;
   }
-    
+
   .tip .tip-image img {
     border: none;
     border-top: 2px solid var(--alternate-background-color);
@@ -630,6 +630,7 @@ footer a {
 }
 .lightbox-button > img {
   max-width: 100%;
+  contain: layout;
 }
 .lightbox-button::after {
   content: "";
@@ -670,6 +671,29 @@ footer a {
       opacity: 1;
     }
   }
+
+  ::view-transition-group(backdrop) {
+    animation-name: show;
+    animation-duration: 0.25s;
+    animation-iteration-count: 1;
+    animation-timing-function: linear;
+    z-index: 1;
+  }
+
+  ::view-transition-group(image) {
+    animation-duration: 0.55s;
+    animation-iteration-count: 1;
+    z-index: 3;
+  }
+
+  ::view-transition-group(button) {
+    animation-delay: 0.55s;
+    animation-name: show;
+    animation-duration: 0.25s;
+    animation-iteration-count: 1;
+    animation-timing-function: linear;
+    z-index: 4;
+  }
 }
 
 :root:has(.lightbox[open]) {
@@ -678,6 +702,8 @@ footer a {
 
 .lightbox::backdrop {
   background: var(--lightbox-backdrop);
+  view-transition-name: backdrop;
+  contain: layout;
 }
 
 .lightbox form {
@@ -689,6 +715,8 @@ footer a {
 }
 
 .lightbox img {
+  view-transition-name: image;
+  contain: layout;
   width: auto;
   max-width: 100%;
 
@@ -696,6 +724,7 @@ footer a {
 	background: none;
 	border-radius: 0;
 }
+
 .lightbox form > span {
   background: var(--alternate-background-color);
   position: sticky;
@@ -722,6 +751,9 @@ footer a {
   background-color: var(--accent-color-lighter);
   color: var(--accent-color-darker);
   transition: 0.25s ease-in-out background;
+  z-index: 1;
+  view-transition-name: button;
+  contain: layout;
 }
 .lightbox button:hover {
   background-color: var(--accent-color);

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -684,11 +684,8 @@ footer a {
   ::view-transition-group(backdrop) {
     animation-name: show;
     animation-duration: 0.25s;
-    animation-iteration-count: 1;
-    animation-timing-function: linear;
     z-index: 1;
   }
-
   ::view-transition-group(image) {
     animation-duration: 0.55s;
     animation-iteration-count: 1;
@@ -699,8 +696,6 @@ footer a {
     animation-delay: 0.55s;
     animation-name: show;
     animation-duration: 0.25s;
-    animation-iteration-count: 1;
-    animation-timing-function: linear;
     z-index: 4;
   }
 }

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -647,6 +647,8 @@ footer a {
     center/80%;
   z-index: 1;
   transition: 0.25s ease-in-out background;
+  view-transition-name: zoombutton;
+  contain: layout;
 }
 
 .lightbox-button:hover::after {
@@ -683,27 +685,29 @@ footer a {
 
   ::view-transition-group(backdrop) {
     animation-duration: 0.25s;
-    z-index: 1;
+    z-index: 10;
   }
   ::view-transition-group(image) {
     animation-duration: 0.5s;
-    z-index: 3;
+    z-index: 30;
   }
 
   ::view-transition-group(button) {
     animation-delay: 0.5s;
     animation-duration: 0.25s;
-    z-index: 4;
+    z-index: 40;
   }
+
+  ::view-transition-group(zoombutton) {
+    animation-delay: 0.5s;
+    animation-duration: 0.25s;
+    z-index: 40;
+    animation-name: show;
 
   ::view-transition-group(dialog) {
-    animation-duration: 0.5s;
-    z-index: 2;
+    animation-delay: 0.5s;
+    z-index: 20;
   }
-}
-
-:root:has(.lightbox[open]) {
-  overflow: clip;
 }
 
 .lightbox::backdrop {
@@ -723,11 +727,10 @@ footer a {
 }
 
 .lightbox img {
-  view-transition-name: image;
-  contain: layout;
   width: auto;
   max-width: 100%;
-
+  contain: layout;
+  
 	padding: 0;
 	background: none;
 	border-radius: 0;


### PR DESCRIPTION
Initial work for #52

Things to do:

- [x] Fallback to old behavior when views transition api is not available
- [x] Animate in the dialog wrapper/container itself without fading out the image inside it
- [x] closing animation
- [x] works on all pages
- [ ] Prevent scrolling back to top
- [ ] Prevent page being scrollable when dialog is opened
- [ ] Staggered animation
- [ ] Works with multiple images on a page (requires unique names in CSS to support this)

---
strangely, it works fine on e.g. http://localhost:8080/tips/en/see-json-responses/ but breaks on http://localhost:8080/tips/en/disable-abusive-debugger-statement/