### PR TITLE
Update get-size-of-resource-types.md: Added Safari

### DIFF
--- a/src/tips/en/get-size-of-resource-types.md
+++ b/src/tips/en/get-size-of-resource-types.md
@@ -2,7 +2,7 @@
 date: 2023-02-16
 authors: Patrick Brosset
 title: See the size of the transferred data for images, scripts, or other resources
-tags: ["network", "perf", "browser:edge", "browser:chrome", "browser:firefox"]
+tags: ["network", "perf", "browser:edge", "browser:chrome", "browser:firefox", "browser:safari"]
 ---
 To know how much data your website transfers between the server and the client to display images, or scripts, or anything else:
 


### PR DESCRIPTION
Transferred size is also available in Safari.

<img width="952" alt="SCR-20230302-vaf" src="https://user-images.githubusercontent.com/38640616/222574786-7c8e95b0-02e4-4980-98c5-f4e54933289e.png">
