### PR TITLE
getEventListeners is supported in Safari

### DIFF
--- a/src/tips/en/list-all-event-listeners.md
+++ b/src/tips/en/list-all-event-listeners.md
@@ -2,7 +2,7 @@
 date: 2023-11-21
 authors: Patrick Brosset
 title: List all event listeners on the entire page
-tags: ["console", "debug", "browser:edge", "browser:chrome"]
+tags: ["console", "debug", "browser:edge", "browser:chrome", "browser:safari"]
 ---
 
 When you don't know a codebase, it might be hard to know where to get started, and what events are being listened to by which elements.


### PR DESCRIPTION
`getEventListeners` also [exists](https://developer.apple.com/documentation/webkitjs/commandlineapihost/1631026-geteventlisteners) in Safari. Evidence,

<img width="840" alt="image" src="https://github.com/captainbrosset/devtools-tips/assets/38640616/cc6ad34b-35ca-4228-853f-438f58cd8faa">
