### PR TITLE
hide 'guide' in list of categories

### DIFF
--- a/src/layouts/home.njk
+++ b/src/layouts/home.njk
@@ -71,7 +71,7 @@
           <li>Tips by category
             <ul class="submenu">
               {%- for tag in getTags(collections) -%}
-              <li><a href="/tag/{{ tag }}/">{{ tag }}</a></li>
+              {%- if tag !== "guide" %}<li><a href="/tag/{{ tag }}/">{{ tag }}</a></li>{%- endif %}
               {%- endfor -%}
             </ul>
           </li>


### PR DESCRIPTION
Since the guide is already linked above, it makes sense to hide it in the list of categories.